### PR TITLE
fix: stale rule reference to mcdr_forcing_description

### DIFF
--- a/project/jsonschema/oae_data_protocol.schema.json
+++ b/project/jsonschema/oae_data_protocol.schema.json
@@ -4178,10 +4178,10 @@
             ],
             "then": {
                 "properties": {
-                    "alkalinity_perturbation_description": {}
+                    "mcdr_forcing_description": {}
                 },
                 "required": [
-                    "alkalinity_perturbation_description"
+                    "mcdr_forcing_description"
                 ]
             },
             "title": "ModelOutputDataset",

--- a/src/oae_data_protocol/datamodel/oae_data_protocol.py
+++ b/src/oae_data_protocol/datamodel/oae_data_protocol.py
@@ -1,5 +1,5 @@
 # Auto generated from oae_data_protocol.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-03-26T10:03:52
+# Generation date: 2026-03-29T13:58:46
 # Schema: OAEDataManagementProtocol
 #
 # id: OAEDataManagementProtocol

--- a/src/oae_data_protocol/schema/dataset.yaml
+++ b/src/oae_data_protocol/schema/dataset.yaml
@@ -207,7 +207,7 @@ classes:
               equals_string: "perturbation"
         postconditions:
           slot_conditions:
-            alkalinity_perturbation_description:
+            mcdr_forcing_description:
               required: true
 
   HardwareConfiguration:


### PR DESCRIPTION
## Summary
- ModelOutputDataset conditional rule still referenced `alkalinity_perturbation_description` after rename to `mcdr_forcing_description`
- Found by schema artifacts audit (submarine-mrv/oae-data-commons#74)

## Test plan
- [x] `make gen-project` — regenerated
- [x] `make test` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)