### PR TITLE
Model upgrades: experiment fields, per-grid input data, multivalued simulation_type

### DIFF
--- a/project/jsonschema/oae_data_protocol.schema.json
+++ b/project/jsonschema/oae_data_protocol.schema.json
@@ -4529,11 +4529,6 @@
                         "null"
                     ]
                 },
-                "input_details": {
-                    "$ref": "#/$defs/ModelInputDetails",
-                    "description": "Details about input data sources used to drive the model.",
-                    "title": "Input Details"
-                },
                 "model_components": {
                     "description": "Components of the model (e.g., physics, biogeochemistry).",
                     "items": {
@@ -4576,10 +4571,20 @@
                     "description": "Latitude/longitude bounds of observed data in experiment, provided in decimal degrees as westernmost longitude, southernmost latitude, easternmost longitude, northernmost latitude. [S, W, N, E]",
                     "title": "Spatial Coverage"
                 },
+                "spin_up_protocol": {
+                    "description": "Description of the model spin-up process.",
+                    "title": "Spin-up Protocol",
+                    "type": "string"
+                },
                 "start_datetime": {
                     "description": "Start date and time of experiment in UTC ISO-8601",
                     "format": "date-time",
                     "title": "Start Date and Time (UTC)",
+                    "type": "string"
+                },
+                "time_stepping_scheme": {
+                    "description": "Time-stepping method and time step used in the simulation.",
+                    "title": "Time-stepping Scheme",
                     "type": "string"
                 }
             },
@@ -4705,6 +4710,11 @@
                     "description": "Description of horizontal resolution (e.g., '3.3 km', '1/12 degree').",
                     "title": "Horizontal Resolution Range",
                     "type": "string"
+                },
+                "input_details": {
+                    "$ref": "#/$defs/ModelInputDetails",
+                    "description": "Details about input data sources used to drive the model on this grid.",
+                    "title": "Input Details"
                 },
                 "n_nodes": {
                     "description": "Number of nodes in the grid (for unstructured grids).",
@@ -4848,9 +4858,7 @@
             "description": "A model simulation output dataset. Contains fields specific to computational model output including simulation configuration, output variables, and hardware information.",
             "if": {
                 "properties": {
-                    "simulation_type": {
-                        "const": "perturbation"
-                    }
+                    "simulation_type": {}
                 },
                 "required": [
                     "simulation_type"
@@ -4947,24 +4955,18 @@
                     "type": "string"
                 },
                 "simulation_type": {
-                    "$ref": "#/$defs/SimulationType",
-                    "description": "Whether this is a counterfactual (control/baseline) or perturbation simulation.",
-                    "title": "Simulation Type"
-                },
-                "spin_up_protocol": {
-                    "description": "Description of the model spin-up process.",
-                    "title": "Spin-up Protocol",
-                    "type": "string"
+                    "description": "The type(s) of model simulation (e.g., counterfactual, perturbation, or both).",
+                    "items": {
+                        "$ref": "#/$defs/SimulationType"
+                    },
+                    "minItems": 1,
+                    "title": "Simulation Type",
+                    "type": "array"
                 },
                 "start_datetime": {
                     "description": "Start date and time of the simulation in UTC ISO-8601.",
                     "format": "date-time",
                     "title": "Start Date and Time",
-                    "type": "string"
-                },
-                "time_stepping_scheme": {
-                    "description": "Time-stepping method and time step used in the simulation.",
-                    "title": "Time-stepping Scheme",
                     "type": "string"
                 }
             },
@@ -5846,7 +5848,8 @@
             "description": "Type of model simulation dataset",
             "enum": [
                 "counterfactual",
-                "perturbation"
+                "perturbation",
+                "other"
             ],
             "title": "SimulationType",
             "type": "string"

--- a/project/typescript/oae_data_protocol.ts
+++ b/project/typescript/oae_data_protocol.ts
@@ -241,6 +241,8 @@ export enum SimulationType {
     counterfactual = "counterfactual",
     /** Simulation with alkalinity perturbation applied */
     perturbation = "perturbation",
+    /** Other simulation type not listed above */
+    other = "other",
 };
 /**
 * Variables commonly included in model simulation output datasets
@@ -1612,18 +1614,14 @@ export interface FieldDataset extends Dataset {
  * A model simulation output dataset. Contains fields specific to computational model output including simulation configuration, output variables, and hardware information.
  */
 export interface ModelOutputDataset extends Dataset {
-    /** Whether this is a counterfactual (control/baseline) or perturbation simulation. */
+    /** The type(s) of model simulation (e.g., counterfactual, perturbation, or both). */
     simulation_type: string,
-    /** Description of the model spin-up process. */
-    spin_up_protocol?: string,
     /** Start date and time of the simulation in UTC ISO-8601. */
     start_datetime: string,
     /** End date and time of the simulation in UTC ISO-8601. */
     end_datetime: string,
     /** Frequency of model output (e.g., 'hourly mean', 'daily mean'). */
     output_frequency?: string,
-    /** Time-stepping method and time step used in the simulation. */
-    time_stepping_scheme?: string,
     /** Description of the mCDR forcing applied in the simulation (e.g., the alkalinity perturbation). Required when simulation_type is "perturbation". */
     mcdr_forcing_description?: string,
     /** Details about the computational hardware used for the simulation. */
@@ -1677,8 +1675,10 @@ export interface Model extends Experiment {
     model_components?: ModelComponent[],
     /** Details about the model grid(s). Use multiple entries for nested grid configurations. */
     grid_details?: ModelGrid[],
-    /** Details about input data sources used to drive the model. */
-    input_details?: ModelInputDetails,
+    /** Description of the model spin-up process. */
+    spin_up_protocol?: string,
+    /** Time-stepping method and time step used in the simulation. */
+    time_stepping_scheme?: string,
 }
 
 
@@ -1735,6 +1735,8 @@ export interface ModelGrid {
     horizontal_resolution_range?: string,
     /** Description of vertical resolution (e.g., 'Max. 4 m near surface, stretching to 500 m at depth'). */
     vertical_resolution_range?: string,
+    /** Details about input data sources used to drive the model on this grid. */
+    input_details?: ModelInputDetails,
 }
 
 

--- a/src/oae_data_protocol/datamodel/oae_data_protocol.py
+++ b/src/oae_data_protocol/datamodel/oae_data_protocol.py
@@ -1,5 +1,5 @@
 # Auto generated from oae_data_protocol.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-07T18:18:12
+# Generation date: 2026-04-07T20:36:48
 # Schema: OAEDataSchema
 #
 # id: https://schema.oaedata.org/OAEDataSchema
@@ -2737,13 +2737,11 @@ class ModelOutputDataset(Dataset):
     experiment_id: str = None
     dataset_type: Union[str, "DatasetType"] = None
     data_submitter: Union[dict, Person] = None
-    simulation_type: Union[str, "SimulationType"] = None
+    simulation_type: Union[Union[str, "SimulationType"], List[Union[str, "SimulationType"]]] = None
     start_datetime: Union[str, XSDDateTime] = None
     end_datetime: Union[str, XSDDateTime] = None
     filenames: Union[str, List[str]] = None
-    spin_up_protocol: Optional[str] = None
     output_frequency: Optional[str] = None
-    time_stepping_scheme: Optional[str] = None
     mcdr_forcing_description: Optional[str] = None
     hardware_configuration: Optional[Union[dict, "HardwareConfiguration"]] = None
     model_output_variables: Optional[Union[Union[str, "ModelOutputVariable"], List[Union[str, "ModelOutputVariable"]]]] = empty_list()
@@ -2751,8 +2749,9 @@ class ModelOutputDataset(Dataset):
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.simulation_type):
             self.MissingRequiredField("simulation_type")
-        if not isinstance(self.simulation_type, SimulationType):
-            self.simulation_type = SimulationType(self.simulation_type)
+        if not isinstance(self.simulation_type, list):
+            self.simulation_type = [self.simulation_type] if self.simulation_type is not None else []
+        self.simulation_type = [v if isinstance(v, SimulationType) else SimulationType(v) for v in self.simulation_type]
 
         if self._is_empty(self.start_datetime):
             self.MissingRequiredField("start_datetime")
@@ -2770,14 +2769,8 @@ class ModelOutputDataset(Dataset):
             self.filenames = [self.filenames] if self.filenames is not None else []
         self.filenames = [v if isinstance(v, str) else str(v) for v in self.filenames]
 
-        if self.spin_up_protocol is not None and not isinstance(self.spin_up_protocol, str):
-            self.spin_up_protocol = str(self.spin_up_protocol)
-
         if self.output_frequency is not None and not isinstance(self.output_frequency, str):
             self.output_frequency = str(self.output_frequency)
-
-        if self.time_stepping_scheme is not None and not isinstance(self.time_stepping_scheme, str):
-            self.time_stepping_scheme = str(self.time_stepping_scheme)
 
         if self.mcdr_forcing_description is not None and not isinstance(self.mcdr_forcing_description, str):
             self.mcdr_forcing_description = str(self.mcdr_forcing_description)
@@ -2891,7 +2884,8 @@ class Model(Experiment):
     model_configuration: Optional[Union[Union[str, URI], List[Union[str, URI]]]] = empty_list()
     model_components: Optional[Union[Union[dict, "ModelComponent"], List[Union[dict, "ModelComponent"]]]] = empty_list()
     grid_details: Optional[Union[Union[dict, "ModelGrid"], List[Union[dict, "ModelGrid"]]]] = empty_list()
-    input_details: Optional[Union[dict, "ModelInputDetails"]] = None
+    spin_up_protocol: Optional[str] = None
+    time_stepping_scheme: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if not isinstance(self.model_configuration, list):
@@ -2906,8 +2900,11 @@ class Model(Experiment):
             self.grid_details = [self.grid_details] if self.grid_details is not None else []
         self.grid_details = [v if isinstance(v, ModelGrid) else ModelGrid(**as_dict(v)) for v in self.grid_details]
 
-        if self.input_details is not None and not isinstance(self.input_details, ModelInputDetails):
-            self.input_details = ModelInputDetails(**as_dict(self.input_details))
+        if self.spin_up_protocol is not None and not isinstance(self.spin_up_protocol, str):
+            self.spin_up_protocol = str(self.spin_up_protocol)
+
+        if self.time_stepping_scheme is not None and not isinstance(self.time_stepping_scheme, str):
+            self.time_stepping_scheme = str(self.time_stepping_scheme)
 
         super().__post_init__(**kwargs)
 
@@ -2987,6 +2984,7 @@ class ModelGrid(YAMLRoot):
     n_nodes: Optional[int] = None
     horizontal_resolution_range: Optional[str] = None
     vertical_resolution_range: Optional[str] = None
+    input_details: Optional[Union[dict, "ModelInputDetails"]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.grid_type):
@@ -3029,6 +3027,9 @@ class ModelGrid(YAMLRoot):
 
         if self.vertical_resolution_range is not None and not isinstance(self.vertical_resolution_range, str):
             self.vertical_resolution_range = str(self.vertical_resolution_range)
+
+        if self.input_details is not None and not isinstance(self.input_details, ModelInputDetails):
+            self.input_details = ModelInputDetails(**as_dict(self.input_details))
 
         super().__post_init__(**kwargs)
 
@@ -4073,6 +4074,9 @@ class SimulationType(EnumDefinitionImpl):
     perturbation = PermissibleValue(
         text="perturbation",
         description="Simulation with alkalinity perturbation applied")
+    other = PermissibleValue(
+        text="other",
+        description="Other simulation type not listed above")
 
     _defn = EnumDefinition(
         name="SimulationType",
@@ -5677,10 +5681,7 @@ slots.fieldDataset__variables = Slot(uri=SCHEMA.variableMeasured, name="fieldDat
                    model_uri=OAE.fieldDataset__variables, domain=None, range=Optional[Union[Union[dict, Variable], List[Union[dict, Variable]]]])
 
 slots.modelOutputDataset__simulation_type = Slot(uri=OAE.simulation_type, name="modelOutputDataset__simulation_type", curie=OAE.curie('simulation_type'),
-                   model_uri=OAE.modelOutputDataset__simulation_type, domain=None, range=Union[str, "SimulationType"])
-
-slots.modelOutputDataset__spin_up_protocol = Slot(uri=OAE.spin_up_protocol, name="modelOutputDataset__spin_up_protocol", curie=OAE.curie('spin_up_protocol'),
-                   model_uri=OAE.modelOutputDataset__spin_up_protocol, domain=None, range=Optional[str])
+                   model_uri=OAE.modelOutputDataset__simulation_type, domain=None, range=Union[Union[str, "SimulationType"], List[Union[str, "SimulationType"]]])
 
 slots.modelOutputDataset__start_datetime = Slot(uri=OAE.start_datetime, name="modelOutputDataset__start_datetime", curie=OAE.curie('start_datetime'),
                    model_uri=OAE.modelOutputDataset__start_datetime, domain=None, range=Union[str, XSDDateTime])
@@ -5690,9 +5691,6 @@ slots.modelOutputDataset__end_datetime = Slot(uri=OAE.end_datetime, name="modelO
 
 slots.modelOutputDataset__output_frequency = Slot(uri=OAE.output_frequency, name="modelOutputDataset__output_frequency", curie=OAE.curie('output_frequency'),
                    model_uri=OAE.modelOutputDataset__output_frequency, domain=None, range=Optional[str])
-
-slots.modelOutputDataset__time_stepping_scheme = Slot(uri=OAE.time_stepping_scheme, name="modelOutputDataset__time_stepping_scheme", curie=OAE.curie('time_stepping_scheme'),
-                   model_uri=OAE.modelOutputDataset__time_stepping_scheme, domain=None, range=Optional[str])
 
 slots.modelOutputDataset__mcdr_forcing_description = Slot(uri=OAE.mcdr_forcing_description, name="modelOutputDataset__mcdr_forcing_description", curie=OAE.curie('mcdr_forcing_description'),
                    model_uri=OAE.modelOutputDataset__mcdr_forcing_description, domain=None, range=Optional[str])
@@ -5742,8 +5740,11 @@ slots.model__model_components = Slot(uri=OAE.model_components, name="model__mode
 slots.model__grid_details = Slot(uri=OAE.grid_details, name="model__grid_details", curie=OAE.curie('grid_details'),
                    model_uri=OAE.model__grid_details, domain=None, range=Optional[Union[Union[dict, ModelGrid], List[Union[dict, ModelGrid]]]])
 
-slots.model__input_details = Slot(uri=OAE.input_details, name="model__input_details", curie=OAE.curie('input_details'),
-                   model_uri=OAE.model__input_details, domain=None, range=Optional[Union[dict, ModelInputDetails]])
+slots.model__spin_up_protocol = Slot(uri=OAE.spin_up_protocol, name="model__spin_up_protocol", curie=OAE.curie('spin_up_protocol'),
+                   model_uri=OAE.model__spin_up_protocol, domain=None, range=Optional[str])
+
+slots.model__time_stepping_scheme = Slot(uri=OAE.time_stepping_scheme, name="model__time_stepping_scheme", curie=OAE.curie('time_stepping_scheme'),
+                   model_uri=OAE.model__time_stepping_scheme, domain=None, range=Optional[str])
 
 slots.modelComponent__model_component_type = Slot(uri=OAE.model_component_type, name="modelComponent__model_component_type", curie=OAE.curie('model_component_type'),
                    model_uri=OAE.modelComponent__model_component_type, domain=None, range=Union[str, "ModelComponentType"])
@@ -5801,6 +5802,9 @@ slots.modelGrid__horizontal_resolution_range = Slot(uri=OAE.horizontal_resolutio
 
 slots.modelGrid__vertical_resolution_range = Slot(uri=OAE.vertical_resolution_range, name="modelGrid__vertical_resolution_range", curie=OAE.curie('vertical_resolution_range'),
                    model_uri=OAE.modelGrid__vertical_resolution_range, domain=None, range=Optional[str])
+
+slots.modelGrid__input_details = Slot(uri=OAE.input_details, name="modelGrid__input_details", curie=OAE.curie('input_details'),
+                   model_uri=OAE.modelGrid__input_details, domain=None, range=Optional[Union[dict, ModelInputDetails]])
 
 slots.modelInputDetails__bathymetry = Slot(uri=OAE.bathymetry, name="modelInputDetails__bathymetry", curie=OAE.curie('bathymetry'),
                    model_uri=OAE.modelInputDetails__bathymetry, domain=None, range=Optional[Union[Union[dict, NamedLink], List[Union[dict, NamedLink]]]])

--- a/src/oae_data_protocol/schema/dataset.yaml
+++ b/src/oae_data_protocol/schema/dataset.yaml
@@ -152,13 +152,11 @@ classes:
     attributes:
       simulation_type:
         title: Simulation Type
-        description: "Whether this is a counterfactual (control/baseline) or perturbation simulation."
+        description: "The type(s) of model simulation (e.g., counterfactual, perturbation, or both)."
         range: SimulationType
+        multivalued: true
         required: true
-      spin_up_protocol:
-        title: Spin-up Protocol
-        description: "Description of the model spin-up process."
-        range: string
+        minimum_cardinality: 1
       start_datetime:
         title: Start Date and Time
         description: "Start date and time of the simulation in UTC ISO-8601."
@@ -172,10 +170,6 @@ classes:
       output_frequency:
         title: Output Frequency
         description: "Frequency of model output (e.g., 'hourly mean', 'daily mean')."
-        range: string
-      time_stepping_scheme:
-        title: Time-stepping Scheme
-        description: "Time-stepping method and time step used in the simulation."
         range: string
       mcdr_forcing_description:
         title: Description of mCDR Forcing
@@ -197,7 +191,8 @@ classes:
       - preconditions:
           slot_conditions:
             simulation_type:
-              equals_string: "perturbation"
+              has_member:
+                equals_string: "perturbation"
         postconditions:
           slot_conditions:
             mcdr_forcing_description:

--- a/src/oae_data_protocol/schema/enums.yaml
+++ b/src/oae_data_protocol/schema/enums.yaml
@@ -268,6 +268,8 @@ enums:
         description: "Control/baseline simulation without alkalinity perturbation"
       perturbation:
         description: "Simulation with alkalinity perturbation applied"
+      other:
+        description: "Other simulation type not listed above"
 
   ModelOutputVariable:
     description: "Variables commonly included in model simulation output datasets"

--- a/src/oae_data_protocol/schema/model.yaml
+++ b/src/oae_data_protocol/schema/model.yaml
@@ -27,11 +27,14 @@ classes:
         range: ModelGrid
         multivalued: true
         inlined_as_list: true
-      input_details:
-        title: Input Details
-        description: "Details about input data sources used to drive the model."
-        range: ModelInputDetails
-        inlined: true
+      spin_up_protocol:
+        title: Spin-up Protocol
+        description: "Description of the model spin-up process."
+        range: string
+      time_stepping_scheme:
+        title: Time-stepping Scheme
+        description: "Time-stepping method and time step used in the simulation."
+        range: string
   ModelComponent:
     description: "A component of a model (e.g., physics, biogeochemistry/ecosystem)."
     slots:
@@ -154,6 +157,11 @@ classes:
         title: Vertical Resolution Range
         description: "Description of vertical resolution (e.g., 'Max. 4 m near surface, stretching to 500 m at depth')."
         range: string
+      input_details:
+        title: Input Details
+        description: "Details about input data sources used to drive the model on this grid."
+        range: ModelInputDetails
+        inlined: true
   ModelInputDetails:
     description: "Details about input data sources used to drive the model."
     attributes:


### PR DESCRIPTION
Addresses submarine-mrv/oae-data-commons#80 and submarine-mrv/oae-data-commons#81.

- Moved `spin_up_protocol` and `time_stepping_scheme` from `ModelOutputDataset` to `Model` (experiment level)
- Nested `input_details` inside `ModelGrid` so each grid carries its own input data sources
- Made `simulation_type` multivalued and added an `other` option to the enum
- Updated the conditional rule so `mcdr_forcing_description` is required when `perturbation` is among the selected simulation types

Coordinate with the form changes: submarine-mrv/oae-metadata-builder#35