### PR TITLE
feat: add Physiological and Socioeconomic variable types

### DIFF
--- a/project/jsonschema/oae_data_protocol.schema.json
+++ b/project/jsonschema/oae_data_protocol.schema.json
@@ -1457,6 +1457,232 @@
             "title": "ContinuousPHVariable",
             "type": "object"
         },
+        "ContinuousPhysiologicalVariable": {
+            "additionalProperties": false,
+            "description": "Physiological response variable from continuous autonomous field sensors (e.g., respiration rates from deployed oxygen consumption monitors, heart rate from bio-loggers).",
+            "properties": {
+                "additional_details": {
+                    "description": "Any additional information about the physiological experiment.",
+                    "title": "Additional Details",
+                    "type": "string"
+                },
+                "analyzing_instrument": {
+                    "$ref": "#/$defs/AnalyzingInstrument",
+                    "description": "Instrument used to analyze the water samples or measure the water body continuously. Instrument includes calibration information.",
+                    "title": "Analyzing instrument"
+                },
+                "analyzing_method": {
+                    "description": "Additional information describing how the sample was analyzed. DOIs provided as applicable.",
+                    "title": "Analyzing Method",
+                    "type": "string"
+                },
+                "biological_subject": {
+                    "description": "Taxonomy (species, genus, or community) being studied (e.g., Crassostrea gigas, coral reef community).",
+                    "title": "Biological Subject",
+                    "type": "string"
+                },
+                "calculation_software_version": {
+                    "description": "Version of the software used to calculate reported values from raw values.",
+                    "title": "Software version for the calculation",
+                    "type": "string"
+                },
+                "dataset_variable_name": {
+                    "description": "The name for the variable as it is identified in the dataset data file. This could be the column header in a CSV or the variable name in a NetCDF file. Standard common recommended column header names can be found in protocol documentation  [here](https://www.carbontosea.org/oae-data-protocol/1-0-0/#column-header-name).",
+                    "title": "Dataset variable name",
+                    "type": "string"
+                },
+                "dataset_variable_name_qc_flag": {
+                    "description": "If applicable, the column header name used for the quality control flag corresponding to this variable.",
+                    "title": "Dataset variable name (Quality Flag)",
+                    "type": "string"
+                },
+                "dataset_variable_name_raw": {
+                    "description": "If applicable, the column header name used for the raw data corresponding to this variable.",
+                    "title": "Dataset variable name (raw)",
+                    "type": "string"
+                },
+                "experiment_location": {
+                    "description": "Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site).",
+                    "title": "Experiment Location",
+                    "type": "string"
+                },
+                "field_replicate_information": {
+                    "description": "Repetition of sample collection and measurement, e.g., triplicate samples.",
+                    "title": "Field replicate information",
+                    "type": "string"
+                },
+                "genesis": {
+                    "const": "measured",
+                    "type": "string"
+                },
+                "life_stage": {
+                    "$ref": "#/$defs/LifeStage",
+                    "description": "Life stage of the organism at time of measurement.",
+                    "title": "Life Stage"
+                },
+                "life_stage_custom": {
+                    "description": "Custom life stage description when \"other\" is selected.",
+                    "title": "Life Stage (custom)",
+                    "type": "string"
+                },
+                "long_name": {
+                    "description": "Full descriptive name of the variable.",
+                    "title": "Variable full name",
+                    "type": "string"
+                },
+                "manipulation_method": {
+                    "description": "How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition).",
+                    "title": "Manipulation Method",
+                    "type": "string"
+                },
+                "measurement_researcher": {
+                    "$ref": "#/$defs/Person",
+                    "description": "The name of the PI whose research team measured or derived this parameter.",
+                    "title": "Researcher who measured the variable"
+                },
+                "method_reference": {
+                    "description": "Citation for the method used.",
+                    "title": "Method Reference",
+                    "type": "string"
+                },
+                "missing_value_indicators": {
+                    "description": "The indicator used to represent missing values in the data file, e.g., -999, NaN, etc.",
+                    "title": "Missing value indicators",
+                    "type": "string"
+                },
+                "observation_type": {
+                    "$ref": "#/$defs/ObservationType",
+                    "title": "Observation Type"
+                },
+                "other_detailed_information": {
+                    "description": "Any additional information about this variable.",
+                    "title": "Other Detailed Information",
+                    "type": "string"
+                },
+                "qc_researcher": {
+                    "$ref": "#/$defs/Person",
+                    "description": "The name of the PI whose research team QCed this parameter.",
+                    "title": "Researcher who QCed this variable"
+                },
+                "qc_researcher_institution": {
+                    "description": "The institution of the PI whose research team QCed this parameter.",
+                    "title": "QC Researcher Institution",
+                    "type": "string"
+                },
+                "qc_steps_taken": {
+                    "description": "Describe what QC steps have been taken to improve the quality of the data (e.g., DOI, software and settings used, outlier removal, etc.).\nIf quality control procedures are described in a separate document uploaded with the data, provide the name of the document here.",
+                    "title": "QC steps taken",
+                    "type": "string"
+                },
+                "raw_data_calculation_method": {
+                    "description": "The method used to calculate reported values from raw sensor data.",
+                    "title": "Method to calculate reported values from raw data",
+                    "type": "string"
+                },
+                "sampling": {
+                    "const": "continuous",
+                    "type": "string"
+                },
+                "sampling_instrument_type": {
+                    "$ref": "#/$defs/SamplingInstrumentType",
+                    "title": "Sampling instrument type"
+                },
+                "sampling_instrument_type_custom": {
+                    "title": "Sampling instrument type (custom)",
+                    "type": "string"
+                },
+                "sampling_method": {
+                    "description": "Method used to collect samples.",
+                    "title": "Sampling Method",
+                    "type": "string"
+                },
+                "schema_class": {
+                    "description": "The schema class name for this variable (e.g., \"DiscretePHVariable\"). Auto-populated by the metadata builder.",
+                    "enum": [
+                        "ContinuousPhysiologicalVariable"
+                    ],
+                    "type": "string"
+                },
+                "species_identification_code": {
+                    "description": "Species reference code from a taxonomic database (e.g., WoRMS AphiaID 140656, ITIS TSN 79861).",
+                    "title": "Species Identification Code",
+                    "type": "string"
+                },
+                "standard_identifier": {
+                    "$ref": "#/$defs/VocabularyItemReference"
+                },
+                "subject_collection_location": {
+                    "description": "Where the biological subjects were collected from.",
+                    "title": "Subject Collection Location",
+                    "type": "string"
+                },
+                "targeted_acidity_levels": {
+                    "description": "Target pCO2 or alkalinity levels for the manipulation experiment (e.g., \"400, 800, 1200 uatm pCO2\").",
+                    "title": "Targeted Acidity or Alkalinity Levels",
+                    "type": "string"
+                },
+                "taxonomic_code_system": {
+                    "$ref": "#/$defs/TaxonomicCodeSystem",
+                    "description": "Which taxonomic code system the identification code refers to.",
+                    "title": "Taxonomic Code System"
+                },
+                "treatment_end_datetime": {
+                    "description": "End of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment End Date/Time",
+                    "type": "string"
+                },
+                "treatment_start_datetime": {
+                    "description": "Start of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment Start Date/Time",
+                    "type": "string"
+                },
+                "uncertainty": {
+                    "description": "It is recommended to provide uncertainty for each data point in the data file. Else provide a single value representative of the dataset.\nIf uncertainty is provided as a variable, please list the column header name here.",
+                    "title": "Uncertainty",
+                    "type": "string"
+                },
+                "uncertainty_definition": {
+                    "description": "A description of the uncertainties involved in this method.",
+                    "title": "How was the uncertainty defined",
+                    "type": "string"
+                },
+                "units": {
+                    "description": "Unit of measurement for this variable.",
+                    "title": "Unit",
+                    "type": "string"
+                },
+                "variable_type": {
+                    "const": "physiological",
+                    "description": "High-level classification of the variable. Determines which standard identifiers are available and, combined with genesis and sampling, which schema class to use.",
+                    "title": "Variable Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "biological_subject",
+                "raw_data_calculation_method",
+                "analyzing_instrument",
+                "sampling_method",
+                "analyzing_method",
+                "observation_type",
+                "sampling",
+                "sampling_instrument_type",
+                "qc_steps_taken",
+                "uncertainty",
+                "uncertainty_definition",
+                "missing_value_indicators",
+                "genesis",
+                "units",
+                "schema_class",
+                "variable_type",
+                "dataset_variable_name",
+                "long_name"
+            ],
+            "title": "ContinuousPhysiologicalVariable",
+            "type": "object"
+        },
         "ContinuousSedimentVariable": {
             "additionalProperties": false,
             "description": "Measured sediment variable collected from continuous autonomous sensor",
@@ -2726,6 +2952,221 @@
             "title": "DiscretePHVariable",
             "type": "object"
         },
+        "DiscretePhysiologicalVariable": {
+            "additionalProperties": false,
+            "description": "Physiological response variable from discrete field samples (e.g., organism growth rates, calcification rates, gene expression from bottle or tissue samples collected in the field).",
+            "properties": {
+                "additional_details": {
+                    "description": "Any additional information about the physiological experiment.",
+                    "title": "Additional Details",
+                    "type": "string"
+                },
+                "analyzing_instrument": {
+                    "$ref": "#/$defs/AnalyzingInstrument",
+                    "description": "Instrument used to analyze the water samples or measure the water body continuously. Instrument includes calibration information.",
+                    "title": "Analyzing instrument"
+                },
+                "analyzing_method": {
+                    "description": "Additional information describing how the sample was analyzed. DOIs provided as applicable.",
+                    "title": "Analyzing Method",
+                    "type": "string"
+                },
+                "biological_subject": {
+                    "description": "Taxonomy (species, genus, or community) being studied (e.g., Crassostrea gigas, coral reef community).",
+                    "title": "Biological Subject",
+                    "type": "string"
+                },
+                "dataset_variable_name": {
+                    "description": "The name for the variable as it is identified in the dataset data file. This could be the column header in a CSV or the variable name in a NetCDF file. Standard common recommended column header names can be found in protocol documentation  [here](https://www.carbontosea.org/oae-data-protocol/1-0-0/#column-header-name).",
+                    "title": "Dataset variable name",
+                    "type": "string"
+                },
+                "dataset_variable_name_qc_flag": {
+                    "description": "If applicable, the column header name used for the quality control flag corresponding to this variable.",
+                    "title": "Dataset variable name (Quality Flag)",
+                    "type": "string"
+                },
+                "dataset_variable_name_raw": {
+                    "description": "If applicable, the column header name used for the raw data corresponding to this variable.",
+                    "title": "Dataset variable name (raw)",
+                    "type": "string"
+                },
+                "experiment_location": {
+                    "description": "Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site).",
+                    "title": "Experiment Location",
+                    "type": "string"
+                },
+                "field_replicate_information": {
+                    "description": "Repetition of sample collection and measurement, e.g., triplicate samples.",
+                    "title": "Field replicate information",
+                    "type": "string"
+                },
+                "genesis": {
+                    "const": "measured",
+                    "type": "string"
+                },
+                "life_stage": {
+                    "$ref": "#/$defs/LifeStage",
+                    "description": "Life stage of the organism at time of measurement.",
+                    "title": "Life Stage"
+                },
+                "life_stage_custom": {
+                    "description": "Custom life stage description when \"other\" is selected.",
+                    "title": "Life Stage (custom)",
+                    "type": "string"
+                },
+                "long_name": {
+                    "description": "Full descriptive name of the variable.",
+                    "title": "Variable full name",
+                    "type": "string"
+                },
+                "manipulation_method": {
+                    "description": "How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition).",
+                    "title": "Manipulation Method",
+                    "type": "string"
+                },
+                "measurement_researcher": {
+                    "$ref": "#/$defs/Person",
+                    "description": "The name of the PI whose research team measured or derived this parameter.",
+                    "title": "Researcher who measured the variable"
+                },
+                "method_reference": {
+                    "description": "Citation for the method used.",
+                    "title": "Method Reference",
+                    "type": "string"
+                },
+                "missing_value_indicators": {
+                    "description": "The indicator used to represent missing values in the data file, e.g., -999, NaN, etc.",
+                    "title": "Missing value indicators",
+                    "type": "string"
+                },
+                "observation_type": {
+                    "$ref": "#/$defs/ObservationType",
+                    "title": "Observation Type"
+                },
+                "other_detailed_information": {
+                    "description": "Any additional information about this variable.",
+                    "title": "Other Detailed Information",
+                    "type": "string"
+                },
+                "qc_researcher": {
+                    "$ref": "#/$defs/Person",
+                    "description": "The name of the PI whose research team QCed this parameter.",
+                    "title": "Researcher who QCed this variable"
+                },
+                "qc_researcher_institution": {
+                    "description": "The institution of the PI whose research team QCed this parameter.",
+                    "title": "QC Researcher Institution",
+                    "type": "string"
+                },
+                "qc_steps_taken": {
+                    "description": "Describe what QC steps have been taken to improve the quality of the data (e.g., DOI, software and settings used, outlier removal, etc.).\nIf quality control procedures are described in a separate document uploaded with the data, provide the name of the document here.",
+                    "title": "QC steps taken",
+                    "type": "string"
+                },
+                "sampling": {
+                    "const": "discrete",
+                    "type": "string"
+                },
+                "sampling_instrument_type": {
+                    "$ref": "#/$defs/SamplingInstrumentType",
+                    "title": "Sampling instrument type"
+                },
+                "sampling_instrument_type_custom": {
+                    "title": "Sampling instrument type (custom)",
+                    "type": "string"
+                },
+                "sampling_method": {
+                    "description": "Method used to collect samples.",
+                    "title": "Sampling Method",
+                    "type": "string"
+                },
+                "schema_class": {
+                    "description": "The schema class name for this variable (e.g., \"DiscretePHVariable\"). Auto-populated by the metadata builder.",
+                    "enum": [
+                        "DiscretePhysiologicalVariable"
+                    ],
+                    "type": "string"
+                },
+                "species_identification_code": {
+                    "description": "Species reference code from a taxonomic database (e.g., WoRMS AphiaID 140656, ITIS TSN 79861).",
+                    "title": "Species Identification Code",
+                    "type": "string"
+                },
+                "standard_identifier": {
+                    "$ref": "#/$defs/VocabularyItemReference"
+                },
+                "subject_collection_location": {
+                    "description": "Where the biological subjects were collected from.",
+                    "title": "Subject Collection Location",
+                    "type": "string"
+                },
+                "targeted_acidity_levels": {
+                    "description": "Target pCO2 or alkalinity levels for the manipulation experiment (e.g., \"400, 800, 1200 uatm pCO2\").",
+                    "title": "Targeted Acidity or Alkalinity Levels",
+                    "type": "string"
+                },
+                "taxonomic_code_system": {
+                    "$ref": "#/$defs/TaxonomicCodeSystem",
+                    "description": "Which taxonomic code system the identification code refers to.",
+                    "title": "Taxonomic Code System"
+                },
+                "treatment_end_datetime": {
+                    "description": "End of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment End Date/Time",
+                    "type": "string"
+                },
+                "treatment_start_datetime": {
+                    "description": "Start of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment Start Date/Time",
+                    "type": "string"
+                },
+                "uncertainty": {
+                    "description": "It is recommended to provide uncertainty for each data point in the data file. Else provide a single value representative of the dataset.\nIf uncertainty is provided as a variable, please list the column header name here.",
+                    "title": "Uncertainty",
+                    "type": "string"
+                },
+                "uncertainty_definition": {
+                    "description": "A description of the uncertainties involved in this method.",
+                    "title": "How was the uncertainty defined",
+                    "type": "string"
+                },
+                "units": {
+                    "description": "Unit of measurement for this variable.",
+                    "title": "Unit",
+                    "type": "string"
+                },
+                "variable_type": {
+                    "const": "physiological",
+                    "description": "High-level classification of the variable. Determines which standard identifiers are available and, combined with genesis and sampling, which schema class to use.",
+                    "title": "Variable Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "biological_subject",
+                "analyzing_instrument",
+                "sampling_method",
+                "analyzing_method",
+                "observation_type",
+                "sampling",
+                "sampling_instrument_type",
+                "qc_steps_taken",
+                "uncertainty",
+                "uncertainty_definition",
+                "missing_value_indicators",
+                "genesis",
+                "units",
+                "schema_class",
+                "variable_type",
+                "dataset_variable_name",
+                "long_name"
+            ],
+            "title": "DiscretePhysiologicalVariable",
+            "type": "object"
+        },
         "DiscreteSedimentVariable": {
             "additionalProperties": false,
             "description": "Measured sediment variable collected from discrete bottle samples",
@@ -3424,6 +3865,9 @@
                                 "$ref": "#/$defs/CalculatedVariable"
                             },
                             {
+                                "$ref": "#/$defs/SocioeconomicVariable"
+                            },
+                            {
                                 "$ref": "#/$defs/DiscreteMeasuredVariable"
                             },
                             {
@@ -3445,6 +3889,9 @@
                                 "$ref": "#/$defs/ContinuousCO2Variable"
                             },
                             {
+                                "$ref": "#/$defs/ContinuousPhysiologicalVariable"
+                            },
+                            {
                                 "$ref": "#/$defs/DiscretePHVariable"
                             },
                             {
@@ -3461,6 +3908,9 @@
                             },
                             {
                                 "$ref": "#/$defs/HPLCVariable"
+                            },
+                            {
+                                "$ref": "#/$defs/DiscretePhysiologicalVariable"
                             }
                         ]
                     },
@@ -4443,6 +4893,19 @@
             ],
             "title": "InterventionWithTracer",
             "type": "object"
+        },
+        "LifeStage": {
+            "description": "Life stage of the biological subject.",
+            "enum": [
+                "egg",
+                "embryo",
+                "larva",
+                "juvenile",
+                "adult",
+                "other"
+            ],
+            "title": "LifeStage",
+            "type": "string"
         },
         "MCDRPathway": {
             "description": "Type of marine Carbon Dioxide Removal (mCDR) pathways.",
@@ -5676,6 +6139,15 @@
             "title": "PropertyValue",
             "type": "object"
         },
+        "QuantitativeQualitative": {
+            "description": "Whether the socioeconomic data is quantitative or qualitative.",
+            "enum": [
+                "quantitative",
+                "qualitative"
+            ],
+            "title": "QuantitativeQualitative",
+            "type": "string"
+        },
         "ResearcherIDType": {
             "description": "",
             "enum": [
@@ -5883,6 +6355,113 @@
             "title": "SimulationType",
             "type": "string"
         },
+        "SocialStudyType": {
+            "description": "Type of social study conducted.",
+            "enum": [
+                "public_perception_survey",
+                "ecosystem_service_valuation_survey",
+                "text_analysis",
+                "other"
+            ],
+            "title": "SocialStudyType",
+            "type": "string"
+        },
+        "SocioeconomicVariable": {
+            "additionalProperties": false,
+            "description": "Socioeconomic variable for social and economic data such as survey responses, ecosystem service valuations, or text analysis. Extends InSituVariable to inherit method_reference and measurement_researcher, but does NOT include QCFields, instrument details, or calibration.",
+            "properties": {
+                "dataset_variable_name": {
+                    "description": "The name for the variable as it is identified in the dataset data file. This could be the column header in a CSV or the variable name in a NetCDF file. Standard common recommended column header names can be found in protocol documentation  [here](https://www.carbontosea.org/oae-data-protocol/1-0-0/#column-header-name).",
+                    "title": "Dataset variable name",
+                    "type": "string"
+                },
+                "dataset_variable_name_qc_flag": {
+                    "description": "If applicable, the column header name used for the quality control flag corresponding to this variable.",
+                    "title": "Dataset variable name (Quality Flag)",
+                    "type": "string"
+                },
+                "dataset_variable_name_raw": {
+                    "description": "If applicable, the column header name used for the raw data corresponding to this variable.",
+                    "title": "Dataset variable name (raw)",
+                    "type": "string"
+                },
+                "genesis": {
+                    "$ref": "#/$defs/GenesisType"
+                },
+                "long_name": {
+                    "description": "Full descriptive name of the variable.",
+                    "title": "Variable full name",
+                    "type": "string"
+                },
+                "measurement_researcher": {
+                    "$ref": "#/$defs/Person",
+                    "description": "The name of the PI whose research team measured or derived this parameter.",
+                    "title": "Researcher who measured the variable"
+                },
+                "method_reference": {
+                    "description": "Citation for the method used.",
+                    "title": "Method Reference",
+                    "type": "string"
+                },
+                "other_detailed_information": {
+                    "description": "Any additional information about this variable.",
+                    "title": "Other Detailed Information",
+                    "type": "string"
+                },
+                "quantitative_or_qualitative": {
+                    "$ref": "#/$defs/QuantitativeQualitative",
+                    "description": "Whether this variable captures quantitative (numerical) or qualitative (categorical/textual) data.",
+                    "title": "Quantitative or Qualitative"
+                },
+                "schema_class": {
+                    "description": "The schema class name for this variable (e.g., \"DiscretePHVariable\"). Auto-populated by the metadata builder.",
+                    "enum": [
+                        "SocioeconomicVariable"
+                    ],
+                    "type": "string"
+                },
+                "social_study_site_characterization": {
+                    "description": "Time period and location description for the social study (e.g., \"2023-2024, coastal communities in Maine, USA\").",
+                    "title": "Study Site Characterization",
+                    "type": "string"
+                },
+                "social_study_type": {
+                    "$ref": "#/$defs/SocialStudyType",
+                    "description": "The type of social science study this variable comes from.",
+                    "title": "Social Study Type"
+                },
+                "social_study_type_custom": {
+                    "description": "Custom study type description when \"other\" is selected.",
+                    "title": "Social Study Type (custom)",
+                    "type": "string"
+                },
+                "standard_identifier": {
+                    "$ref": "#/$defs/VocabularyItemReference"
+                },
+                "units": {
+                    "description": "Unit of measurement for this variable.",
+                    "title": "Unit",
+                    "type": "string"
+                },
+                "variable_type": {
+                    "const": "socioeconomic",
+                    "description": "High-level classification of the variable. Determines which standard identifiers are available and, combined with genesis and sampling, which schema class to use.",
+                    "title": "Variable Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "quantitative_or_qualitative",
+                "genesis",
+                "units",
+                "schema_class",
+                "variable_type",
+                "dataset_variable_name",
+                "long_name"
+            ],
+            "title": "SocioeconomicVariable",
+            "type": "object"
+        },
         "SpatialCoverage": {
             "additionalProperties": false,
             "description": "A bounding box defined by latitude and longitude coordinates.",
@@ -5928,6 +6507,17 @@
             },
             "title": "StandardGas",
             "type": "object"
+        },
+        "TaxonomicCodeSystem": {
+            "description": "Taxonomic code system used for species identification.",
+            "enum": [
+                "itis",
+                "worms",
+                "col",
+                "pbdb"
+            ],
+            "title": "TaxonomicCodeSystem",
+            "type": "string"
         },
         "TemperatureSensor": {
             "additionalProperties": false,
@@ -6194,6 +6784,8 @@
                 "co2",
                 "sediment",
                 "hplc",
+                "physiological",
+                "socioeconomic",
                 "other",
                 "non_measured"
             ],

--- a/project/jsonschema/oae_data_protocol.schema.json
+++ b/project/jsonschema/oae_data_protocol.schema.json
@@ -1461,11 +1461,6 @@
             "additionalProperties": false,
             "description": "Physiological response variable from continuous autonomous field sensors (e.g., respiration rates from deployed oxygen consumption monitors, heart rate from bio-loggers).",
             "properties": {
-                "additional_details": {
-                    "description": "Any additional information about the physiological experiment.",
-                    "title": "Additional Details",
-                    "type": "string"
-                },
                 "analyzing_instrument": {
                     "$ref": "#/$defs/AnalyzingInstrument",
                     "description": "Instrument used to analyze the water samples or measure the water body continuously. Instrument includes calibration information.",
@@ -1501,11 +1496,6 @@
                     "title": "Dataset variable name (raw)",
                     "type": "string"
                 },
-                "experiment_location": {
-                    "description": "Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site).",
-                    "title": "Experiment Location",
-                    "type": "string"
-                },
                 "field_replicate_information": {
                     "description": "Repetition of sample collection and measurement, e.g., triplicate samples.",
                     "title": "Field replicate information",
@@ -1528,11 +1518,6 @@
                 "long_name": {
                     "description": "Full descriptive name of the variable.",
                     "title": "Variable full name",
-                    "type": "string"
-                },
-                "manipulation_method": {
-                    "description": "How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition).",
-                    "title": "Manipulation Method",
                     "type": "string"
                 },
                 "measurement_researcher": {
@@ -1611,32 +1596,10 @@
                 "standard_identifier": {
                     "$ref": "#/$defs/VocabularyItemReference"
                 },
-                "subject_collection_location": {
-                    "description": "Where the biological subjects were collected from.",
-                    "title": "Subject Collection Location",
-                    "type": "string"
-                },
-                "targeted_acidity_levels": {
-                    "description": "Target pCO2 or alkalinity levels for the manipulation experiment (e.g., \"400, 800, 1200 uatm pCO2\").",
-                    "title": "Targeted Acidity or Alkalinity Levels",
-                    "type": "string"
-                },
                 "taxonomic_code_system": {
                     "$ref": "#/$defs/TaxonomicCodeSystem",
                     "description": "Which taxonomic code system the identification code refers to.",
                     "title": "Taxonomic Code System"
-                },
-                "treatment_end_datetime": {
-                    "description": "End of the experimental treatment period (UTC).",
-                    "format": "date-time",
-                    "title": "Treatment End Date/Time",
-                    "type": "string"
-                },
-                "treatment_start_datetime": {
-                    "description": "Start of the experimental treatment period (UTC).",
-                    "format": "date-time",
-                    "title": "Treatment Start Date/Time",
-                    "type": "string"
                 },
                 "uncertainty": {
                     "description": "It is recommended to provide uncertainty for each data point in the data file. Else provide a single value representative of the dataset.\nIf uncertainty is provided as a variable, please list the column header name here.",
@@ -2956,11 +2919,6 @@
             "additionalProperties": false,
             "description": "Physiological response variable from discrete field samples (e.g., organism growth rates, calcification rates, gene expression from bottle or tissue samples collected in the field).",
             "properties": {
-                "additional_details": {
-                    "description": "Any additional information about the physiological experiment.",
-                    "title": "Additional Details",
-                    "type": "string"
-                },
                 "analyzing_instrument": {
                     "$ref": "#/$defs/AnalyzingInstrument",
                     "description": "Instrument used to analyze the water samples or measure the water body continuously. Instrument includes calibration information.",
@@ -2991,11 +2949,6 @@
                     "title": "Dataset variable name (raw)",
                     "type": "string"
                 },
-                "experiment_location": {
-                    "description": "Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site).",
-                    "title": "Experiment Location",
-                    "type": "string"
-                },
                 "field_replicate_information": {
                     "description": "Repetition of sample collection and measurement, e.g., triplicate samples.",
                     "title": "Field replicate information",
@@ -3018,11 +2971,6 @@
                 "long_name": {
                     "description": "Full descriptive name of the variable.",
                     "title": "Variable full name",
-                    "type": "string"
-                },
-                "manipulation_method": {
-                    "description": "How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition).",
-                    "title": "Manipulation Method",
                     "type": "string"
                 },
                 "measurement_researcher": {
@@ -3096,32 +3044,10 @@
                 "standard_identifier": {
                     "$ref": "#/$defs/VocabularyItemReference"
                 },
-                "subject_collection_location": {
-                    "description": "Where the biological subjects were collected from.",
-                    "title": "Subject Collection Location",
-                    "type": "string"
-                },
-                "targeted_acidity_levels": {
-                    "description": "Target pCO2 or alkalinity levels for the manipulation experiment (e.g., \"400, 800, 1200 uatm pCO2\").",
-                    "title": "Targeted Acidity or Alkalinity Levels",
-                    "type": "string"
-                },
                 "taxonomic_code_system": {
                     "$ref": "#/$defs/TaxonomicCodeSystem",
                     "description": "Which taxonomic code system the identification code refers to.",
                     "title": "Taxonomic Code System"
-                },
-                "treatment_end_datetime": {
-                    "description": "End of the experimental treatment period (UTC).",
-                    "format": "date-time",
-                    "title": "Treatment End Date/Time",
-                    "type": "string"
-                },
-                "treatment_start_datetime": {
-                    "description": "Start of the experimental treatment period (UTC).",
-                    "format": "date-time",
-                    "title": "Treatment Start Date/Time",
-                    "type": "string"
                 },
                 "uncertainty": {
                     "description": "It is recommended to provide uncertainty for each data point in the data file. Else provide a single value representative of the dataset.\nIf uncertainty is provided as a variable, please list the column header name here.",

--- a/project/jsonschema/oae_data_protocol.validation.schema.json
+++ b/project/jsonschema/oae_data_protocol.validation.schema.json
@@ -1993,6 +1993,320 @@
             "title": "ContinuousPHVariable",
             "type": "object"
         },
+        "ContinuousPhysiologicalVariable": {
+            "additionalProperties": false,
+            "description": "Physiological response variable from continuous autonomous field sensors (e.g., respiration rates from deployed oxygen consumption monitors, heart rate from bio-loggers).",
+            "properties": {
+                "additional_details": {
+                    "description": "Any additional information about the physiological experiment.",
+                    "title": "Additional Details",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "analyzing_instrument": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AnalyzingInstrument"
+                        },
+                        {
+                            "$ref": "#/$defs/PHInstrument"
+                        },
+                        {
+                            "$ref": "#/$defs/CRMInstrument"
+                        },
+                        {
+                            "$ref": "#/$defs/CO2GasDetector"
+                        },
+                        {
+                            "$ref": "#/$defs/ContinuousCO2GasDetector"
+                        }
+                    ],
+                    "description": "Instrument used to analyze the water samples or measure the water body continuously. Instrument includes calibration information.",
+                    "title": "Analyzing instrument"
+                },
+                "analyzing_method": {
+                    "description": "Additional information describing how the sample was analyzed. DOIs provided as applicable.",
+                    "title": "Analyzing Method",
+                    "type": "string"
+                },
+                "biological_subject": {
+                    "description": "Taxonomy (species, genus, or community) being studied (e.g., Crassostrea gigas, coral reef community).",
+                    "title": "Biological Subject",
+                    "type": "string"
+                },
+                "calculation_software_version": {
+                    "description": "Version of the software used to calculate reported values from raw values.",
+                    "title": "Software version for the calculation",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dataset_variable_name": {
+                    "description": "The name for the variable as it is identified in the dataset data file. This could be the column header in a CSV or the variable name in a NetCDF file. Standard common recommended column header names can be found in protocol documentation  [here](https://www.carbontosea.org/oae-data-protocol/1-0-0/#column-header-name).",
+                    "title": "Dataset variable name",
+                    "type": "string"
+                },
+                "dataset_variable_name_qc_flag": {
+                    "description": "If applicable, the column header name used for the quality control flag corresponding to this variable.",
+                    "title": "Dataset variable name (Quality Flag)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dataset_variable_name_raw": {
+                    "description": "If applicable, the column header name used for the raw data corresponding to this variable.",
+                    "title": "Dataset variable name (raw)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "experiment_location": {
+                    "description": "Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site).",
+                    "title": "Experiment Location",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "field_replicate_information": {
+                    "description": "Repetition of sample collection and measurement, e.g., triplicate samples.",
+                    "title": "Field replicate information",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "genesis": {
+                    "const": "measured",
+                    "type": "string"
+                },
+                "life_stage": {
+                    "$ref": "#/$defs/LifeStage",
+                    "description": "Life stage of the organism at time of measurement.",
+                    "title": "Life Stage"
+                },
+                "life_stage_custom": {
+                    "description": "Custom life stage description when \"other\" is selected.",
+                    "title": "Life Stage (custom)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "long_name": {
+                    "description": "Full descriptive name of the variable.",
+                    "title": "Variable full name",
+                    "type": "string"
+                },
+                "manipulation_method": {
+                    "description": "How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition).",
+                    "title": "Manipulation Method",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "measurement_researcher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Person"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The name of the PI whose research team measured or derived this parameter.",
+                    "title": "Researcher who measured the variable"
+                },
+                "method_reference": {
+                    "description": "Citation for the method used.",
+                    "title": "Method Reference",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "missing_value_indicators": {
+                    "description": "The indicator used to represent missing values in the data file, e.g., -999, NaN, etc.",
+                    "title": "Missing value indicators",
+                    "type": "string"
+                },
+                "observation_type": {
+                    "$ref": "#/$defs/ObservationType",
+                    "title": "Observation Type"
+                },
+                "other_detailed_information": {
+                    "description": "Any additional information about this variable.",
+                    "title": "Other Detailed Information",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "qc_researcher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Person"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The name of the PI whose research team QCed this parameter.",
+                    "title": "Researcher who QCed this variable"
+                },
+                "qc_researcher_institution": {
+                    "description": "The institution of the PI whose research team QCed this parameter.",
+                    "title": "QC Researcher Institution",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "qc_steps_taken": {
+                    "description": "Describe what QC steps have been taken to improve the quality of the data (e.g., DOI, software and settings used, outlier removal, etc.).\nIf quality control procedures are described in a separate document uploaded with the data, provide the name of the document here.",
+                    "title": "QC steps taken",
+                    "type": "string"
+                },
+                "raw_data_calculation_method": {
+                    "description": "The method used to calculate reported values from raw sensor data.",
+                    "title": "Method to calculate reported values from raw data",
+                    "type": "string"
+                },
+                "sampling": {
+                    "const": "continuous",
+                    "type": "string"
+                },
+                "sampling_instrument_type": {
+                    "$ref": "#/$defs/SamplingInstrumentType",
+                    "title": "Sampling instrument type"
+                },
+                "sampling_instrument_type_custom": {
+                    "title": "Sampling instrument type (custom)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "sampling_method": {
+                    "description": "Method used to collect samples.",
+                    "title": "Sampling Method",
+                    "type": "string"
+                },
+                "schema_class": {
+                    "description": "The schema class name for this variable (e.g., \"DiscretePHVariable\"). Auto-populated by the metadata builder.",
+                    "enum": [
+                        "ContinuousPhysiologicalVariable"
+                    ],
+                    "type": "string"
+                },
+                "species_identification_code": {
+                    "description": "Species reference code from a taxonomic database (e.g., WoRMS AphiaID 140656, ITIS TSN 79861).",
+                    "title": "Species Identification Code",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "standard_identifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/VocabularyItemReference"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "subject_collection_location": {
+                    "description": "Where the biological subjects were collected from.",
+                    "title": "Subject Collection Location",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "targeted_acidity_levels": {
+                    "description": "Target pCO2 or alkalinity levels for the manipulation experiment (e.g., \"400, 800, 1200 uatm pCO2\").",
+                    "title": "Targeted Acidity or Alkalinity Levels",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "taxonomic_code_system": {
+                    "$ref": "#/$defs/TaxonomicCodeSystem",
+                    "description": "Which taxonomic code system the identification code refers to.",
+                    "title": "Taxonomic Code System"
+                },
+                "treatment_end_datetime": {
+                    "description": "End of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment End Date/Time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "treatment_start_datetime": {
+                    "description": "Start of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment Start Date/Time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uncertainty": {
+                    "description": "It is recommended to provide uncertainty for each data point in the data file. Else provide a single value representative of the dataset.\nIf uncertainty is provided as a variable, please list the column header name here.",
+                    "title": "Uncertainty",
+                    "type": "string"
+                },
+                "uncertainty_definition": {
+                    "description": "A description of the uncertainties involved in this method.",
+                    "title": "How was the uncertainty defined",
+                    "type": "string"
+                },
+                "units": {
+                    "description": "Unit of measurement for this variable.",
+                    "title": "Unit",
+                    "type": "string"
+                },
+                "variable_type": {
+                    "const": "physiological",
+                    "description": "High-level classification of the variable. Determines which standard identifiers are available and, combined with genesis and sampling, which schema class to use.",
+                    "title": "Variable Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "biological_subject",
+                "raw_data_calculation_method",
+                "analyzing_instrument",
+                "sampling_method",
+                "analyzing_method",
+                "observation_type",
+                "sampling",
+                "sampling_instrument_type",
+                "qc_steps_taken",
+                "uncertainty",
+                "uncertainty_definition",
+                "missing_value_indicators",
+                "genesis",
+                "units",
+                "schema_class",
+                "variable_type",
+                "dataset_variable_name",
+                "long_name"
+            ],
+            "title": "ContinuousPhysiologicalVariable",
+            "type": "object"
+        },
         "ContinuousSedimentVariable": {
             "additionalProperties": false,
             "description": "Measured sediment variable collected from continuous autonomous sensor",
@@ -3642,6 +3956,306 @@
             "title": "DiscretePHVariable",
             "type": "object"
         },
+        "DiscretePhysiologicalVariable": {
+            "additionalProperties": false,
+            "description": "Physiological response variable from discrete field samples (e.g., organism growth rates, calcification rates, gene expression from bottle or tissue samples collected in the field).",
+            "properties": {
+                "additional_details": {
+                    "description": "Any additional information about the physiological experiment.",
+                    "title": "Additional Details",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "analyzing_instrument": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AnalyzingInstrument"
+                        },
+                        {
+                            "$ref": "#/$defs/PHInstrument"
+                        },
+                        {
+                            "$ref": "#/$defs/CRMInstrument"
+                        },
+                        {
+                            "$ref": "#/$defs/CO2GasDetector"
+                        },
+                        {
+                            "$ref": "#/$defs/ContinuousCO2GasDetector"
+                        }
+                    ],
+                    "description": "Instrument used to analyze the water samples or measure the water body continuously. Instrument includes calibration information.",
+                    "title": "Analyzing instrument"
+                },
+                "analyzing_method": {
+                    "description": "Additional information describing how the sample was analyzed. DOIs provided as applicable.",
+                    "title": "Analyzing Method",
+                    "type": "string"
+                },
+                "biological_subject": {
+                    "description": "Taxonomy (species, genus, or community) being studied (e.g., Crassostrea gigas, coral reef community).",
+                    "title": "Biological Subject",
+                    "type": "string"
+                },
+                "dataset_variable_name": {
+                    "description": "The name for the variable as it is identified in the dataset data file. This could be the column header in a CSV or the variable name in a NetCDF file. Standard common recommended column header names can be found in protocol documentation  [here](https://www.carbontosea.org/oae-data-protocol/1-0-0/#column-header-name).",
+                    "title": "Dataset variable name",
+                    "type": "string"
+                },
+                "dataset_variable_name_qc_flag": {
+                    "description": "If applicable, the column header name used for the quality control flag corresponding to this variable.",
+                    "title": "Dataset variable name (Quality Flag)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dataset_variable_name_raw": {
+                    "description": "If applicable, the column header name used for the raw data corresponding to this variable.",
+                    "title": "Dataset variable name (raw)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "experiment_location": {
+                    "description": "Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site).",
+                    "title": "Experiment Location",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "field_replicate_information": {
+                    "description": "Repetition of sample collection and measurement, e.g., triplicate samples.",
+                    "title": "Field replicate information",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "genesis": {
+                    "const": "measured",
+                    "type": "string"
+                },
+                "life_stage": {
+                    "$ref": "#/$defs/LifeStage",
+                    "description": "Life stage of the organism at time of measurement.",
+                    "title": "Life Stage"
+                },
+                "life_stage_custom": {
+                    "description": "Custom life stage description when \"other\" is selected.",
+                    "title": "Life Stage (custom)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "long_name": {
+                    "description": "Full descriptive name of the variable.",
+                    "title": "Variable full name",
+                    "type": "string"
+                },
+                "manipulation_method": {
+                    "description": "How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition).",
+                    "title": "Manipulation Method",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "measurement_researcher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Person"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The name of the PI whose research team measured or derived this parameter.",
+                    "title": "Researcher who measured the variable"
+                },
+                "method_reference": {
+                    "description": "Citation for the method used.",
+                    "title": "Method Reference",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "missing_value_indicators": {
+                    "description": "The indicator used to represent missing values in the data file, e.g., -999, NaN, etc.",
+                    "title": "Missing value indicators",
+                    "type": "string"
+                },
+                "observation_type": {
+                    "$ref": "#/$defs/ObservationType",
+                    "title": "Observation Type"
+                },
+                "other_detailed_information": {
+                    "description": "Any additional information about this variable.",
+                    "title": "Other Detailed Information",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "qc_researcher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Person"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The name of the PI whose research team QCed this parameter.",
+                    "title": "Researcher who QCed this variable"
+                },
+                "qc_researcher_institution": {
+                    "description": "The institution of the PI whose research team QCed this parameter.",
+                    "title": "QC Researcher Institution",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "qc_steps_taken": {
+                    "description": "Describe what QC steps have been taken to improve the quality of the data (e.g., DOI, software and settings used, outlier removal, etc.).\nIf quality control procedures are described in a separate document uploaded with the data, provide the name of the document here.",
+                    "title": "QC steps taken",
+                    "type": "string"
+                },
+                "sampling": {
+                    "const": "discrete",
+                    "type": "string"
+                },
+                "sampling_instrument_type": {
+                    "$ref": "#/$defs/SamplingInstrumentType",
+                    "title": "Sampling instrument type"
+                },
+                "sampling_instrument_type_custom": {
+                    "title": "Sampling instrument type (custom)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "sampling_method": {
+                    "description": "Method used to collect samples.",
+                    "title": "Sampling Method",
+                    "type": "string"
+                },
+                "schema_class": {
+                    "description": "The schema class name for this variable (e.g., \"DiscretePHVariable\"). Auto-populated by the metadata builder.",
+                    "enum": [
+                        "DiscretePhysiologicalVariable"
+                    ],
+                    "type": "string"
+                },
+                "species_identification_code": {
+                    "description": "Species reference code from a taxonomic database (e.g., WoRMS AphiaID 140656, ITIS TSN 79861).",
+                    "title": "Species Identification Code",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "standard_identifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/VocabularyItemReference"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "subject_collection_location": {
+                    "description": "Where the biological subjects were collected from.",
+                    "title": "Subject Collection Location",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "targeted_acidity_levels": {
+                    "description": "Target pCO2 or alkalinity levels for the manipulation experiment (e.g., \"400, 800, 1200 uatm pCO2\").",
+                    "title": "Targeted Acidity or Alkalinity Levels",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "taxonomic_code_system": {
+                    "$ref": "#/$defs/TaxonomicCodeSystem",
+                    "description": "Which taxonomic code system the identification code refers to.",
+                    "title": "Taxonomic Code System"
+                },
+                "treatment_end_datetime": {
+                    "description": "End of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment End Date/Time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "treatment_start_datetime": {
+                    "description": "Start of the experimental treatment period (UTC).",
+                    "format": "date-time",
+                    "title": "Treatment Start Date/Time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uncertainty": {
+                    "description": "It is recommended to provide uncertainty for each data point in the data file. Else provide a single value representative of the dataset.\nIf uncertainty is provided as a variable, please list the column header name here.",
+                    "title": "Uncertainty",
+                    "type": "string"
+                },
+                "uncertainty_definition": {
+                    "description": "A description of the uncertainties involved in this method.",
+                    "title": "How was the uncertainty defined",
+                    "type": "string"
+                },
+                "units": {
+                    "description": "Unit of measurement for this variable.",
+                    "title": "Unit",
+                    "type": "string"
+                },
+                "variable_type": {
+                    "const": "physiological",
+                    "description": "High-level classification of the variable. Determines which standard identifiers are available and, combined with genesis and sampling, which schema class to use.",
+                    "title": "Variable Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "biological_subject",
+                "analyzing_instrument",
+                "sampling_method",
+                "analyzing_method",
+                "observation_type",
+                "sampling",
+                "sampling_instrument_type",
+                "qc_steps_taken",
+                "uncertainty",
+                "uncertainty_definition",
+                "missing_value_indicators",
+                "genesis",
+                "units",
+                "schema_class",
+                "variable_type",
+                "dataset_variable_name",
+                "long_name"
+            ],
+            "title": "DiscretePhysiologicalVariable",
+            "type": "object"
+        },
         "DiscreteSedimentVariable": {
             "additionalProperties": false,
             "description": "Measured sediment variable collected from discrete bottle samples",
@@ -4478,6 +5092,9 @@
                                 "$ref": "#/$defs/CalculatedVariable"
                             },
                             {
+                                "$ref": "#/$defs/SocioeconomicVariable"
+                            },
+                            {
                                 "$ref": "#/$defs/DiscreteMeasuredVariable"
                             },
                             {
@@ -4499,6 +5116,9 @@
                                 "$ref": "#/$defs/ContinuousCO2Variable"
                             },
                             {
+                                "$ref": "#/$defs/ContinuousPhysiologicalVariable"
+                            },
+                            {
                                 "$ref": "#/$defs/DiscretePHVariable"
                             },
                             {
@@ -4515,6 +5135,9 @@
                             },
                             {
                                 "$ref": "#/$defs/HPLCVariable"
+                            },
+                            {
+                                "$ref": "#/$defs/DiscretePhysiologicalVariable"
                             }
                         ]
                     },
@@ -5687,6 +6310,19 @@
             ],
             "title": "InterventionWithTracer",
             "type": "object"
+        },
+        "LifeStage": {
+            "description": "Life stage of the biological subject.",
+            "enum": [
+                "egg",
+                "embryo",
+                "larva",
+                "juvenile",
+                "adult",
+                "other"
+            ],
+            "title": "LifeStage",
+            "type": "string"
         },
         "MCDRPathway": {
             "description": "Type of marine Carbon Dioxide Removal (mCDR) pathways.",
@@ -7214,6 +7850,15 @@
             "title": "PropertyValue",
             "type": "object"
         },
+        "QuantitativeQualitative": {
+            "description": "Whether the socioeconomic data is quantitative or qualitative.",
+            "enum": [
+                "quantitative",
+                "qualitative"
+            ],
+            "title": "QuantitativeQualitative",
+            "type": "string"
+        },
         "ResearcherIDType": {
             "description": "",
             "enum": [
@@ -7424,6 +8069,145 @@
             "title": "SimulationType",
             "type": "string"
         },
+        "SocialStudyType": {
+            "description": "Type of social study conducted.",
+            "enum": [
+                "public_perception_survey",
+                "ecosystem_service_valuation_survey",
+                "text_analysis",
+                "other"
+            ],
+            "title": "SocialStudyType",
+            "type": "string"
+        },
+        "SocioeconomicVariable": {
+            "additionalProperties": false,
+            "description": "Socioeconomic variable for social and economic data such as survey responses, ecosystem service valuations, or text analysis. Extends InSituVariable to inherit method_reference and measurement_researcher, but does NOT include QCFields, instrument details, or calibration.",
+            "properties": {
+                "dataset_variable_name": {
+                    "description": "The name for the variable as it is identified in the dataset data file. This could be the column header in a CSV or the variable name in a NetCDF file. Standard common recommended column header names can be found in protocol documentation  [here](https://www.carbontosea.org/oae-data-protocol/1-0-0/#column-header-name).",
+                    "title": "Dataset variable name",
+                    "type": "string"
+                },
+                "dataset_variable_name_qc_flag": {
+                    "description": "If applicable, the column header name used for the quality control flag corresponding to this variable.",
+                    "title": "Dataset variable name (Quality Flag)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dataset_variable_name_raw": {
+                    "description": "If applicable, the column header name used for the raw data corresponding to this variable.",
+                    "title": "Dataset variable name (raw)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "genesis": {
+                    "$ref": "#/$defs/GenesisType"
+                },
+                "long_name": {
+                    "description": "Full descriptive name of the variable.",
+                    "title": "Variable full name",
+                    "type": "string"
+                },
+                "measurement_researcher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Person"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The name of the PI whose research team measured or derived this parameter.",
+                    "title": "Researcher who measured the variable"
+                },
+                "method_reference": {
+                    "description": "Citation for the method used.",
+                    "title": "Method Reference",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "other_detailed_information": {
+                    "description": "Any additional information about this variable.",
+                    "title": "Other Detailed Information",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "quantitative_or_qualitative": {
+                    "$ref": "#/$defs/QuantitativeQualitative",
+                    "description": "Whether this variable captures quantitative (numerical) or qualitative (categorical/textual) data.",
+                    "title": "Quantitative or Qualitative"
+                },
+                "schema_class": {
+                    "description": "The schema class name for this variable (e.g., \"DiscretePHVariable\"). Auto-populated by the metadata builder.",
+                    "enum": [
+                        "SocioeconomicVariable"
+                    ],
+                    "type": "string"
+                },
+                "social_study_site_characterization": {
+                    "description": "Time period and location description for the social study (e.g., \"2023-2024, coastal communities in Maine, USA\").",
+                    "title": "Study Site Characterization",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "social_study_type": {
+                    "$ref": "#/$defs/SocialStudyType",
+                    "description": "The type of social science study this variable comes from.",
+                    "title": "Social Study Type"
+                },
+                "social_study_type_custom": {
+                    "description": "Custom study type description when \"other\" is selected.",
+                    "title": "Social Study Type (custom)",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "standard_identifier": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/VocabularyItemReference"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "units": {
+                    "description": "Unit of measurement for this variable.",
+                    "title": "Unit",
+                    "type": "string"
+                },
+                "variable_type": {
+                    "const": "socioeconomic",
+                    "description": "High-level classification of the variable. Determines which standard identifiers are available and, combined with genesis and sampling, which schema class to use.",
+                    "title": "Variable Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "quantitative_or_qualitative",
+                "genesis",
+                "units",
+                "schema_class",
+                "variable_type",
+                "dataset_variable_name",
+                "long_name"
+            ],
+            "title": "SocioeconomicVariable",
+            "type": "object"
+        },
         "SpatialCoverage": {
             "additionalProperties": false,
             "description": "A bounding box defined by latitude and longitude coordinates.",
@@ -7478,6 +8262,17 @@
             },
             "title": "StandardGas",
             "type": "object"
+        },
+        "TaxonomicCodeSystem": {
+            "description": "Taxonomic code system used for species identification.",
+            "enum": [
+                "itis",
+                "worms",
+                "col",
+                "pbdb"
+            ],
+            "title": "TaxonomicCodeSystem",
+            "type": "string"
         },
         "TemperatureSensor": {
             "additionalProperties": false,
@@ -7793,6 +8588,8 @@
                 "co2",
                 "sediment",
                 "hplc",
+                "physiological",
+                "socioeconomic",
                 "other",
                 "non_measured"
             ],

--- a/project/typescript/oae_data_protocol.ts
+++ b/project/typescript/oae_data_protocol.ts
@@ -606,6 +606,10 @@ export enum VariableType {
     sediment = "sediment",
     /** HPLC pigment analysis — use with HPLCVariable (always discrete, always measured) */
     hplc = "hplc",
+    /** Physiological response variable — organism response data from field experiments. Use with Discrete/ContinuousPhysiologicalVariable or CalculatedVariable. */
+    physiological = "physiological",
+    /** Socioeconomic variable — social and economic data. Use only with SocioeconomicVariable. Does not include QC fields. */
+    socioeconomic = "socioeconomic",
     /** Any directly measured or calculated variable that does not fall into a specific category above (e.g., temperature, salinity, conductivity, pressure, fluorescence). Use with DiscreteMeasuredVariable, ContinuousMeasuredVariable, or CalculatedVariable. */
     other = "other",
     /** Contextual or ancillary columns that are not directly measured or calculated by the project — identifiers, timestamps, coordinates and external source data. QC flag columns should NOT be listed as separate variables; instead set dataset_variable_name_qc_flag on the parent variable. Use only with NonMeasuredVariable. */
@@ -651,6 +655,54 @@ export enum ConcentrationBasis {
     per_volume = "per_volume",
     /** Concentration expressed per unit mass (e.g., μmol/kg-seawater) */
     per_mass = "per_mass",
+};
+/**
+* Taxonomic code system used for species identification.
+*/
+export enum TaxonomicCodeSystem {
+    
+    /** Integrated Taxonomic Information System */
+    itis = "itis",
+    /** World Register of Marine Species */
+    worms = "worms",
+    /** Catalogue of Life */
+    col = "col",
+    /** Paleobiology Database */
+    pbdb = "pbdb",
+};
+/**
+* Life stage of the biological subject.
+*/
+export enum LifeStage {
+    
+    egg = "egg",
+    embryo = "embryo",
+    larva = "larva",
+    juvenile = "juvenile",
+    adult = "adult",
+    other = "other",
+};
+/**
+* Whether the socioeconomic data is quantitative or qualitative.
+*/
+export enum QuantitativeQualitative {
+    
+    quantitative = "quantitative",
+    qualitative = "qualitative",
+};
+/**
+* Type of social study conducted.
+*/
+export enum SocialStudyType {
+    
+    /** Public perception survey */
+    public_perception_survey = "public_perception_survey",
+    /** Ecosystem service valuation survey */
+    ecosystem_service_valuation_survey = "ecosystem_service_valuation_survey",
+    /** Text analysis */
+    text_analysis = "text_analysis",
+    /** Other study type */
+    other = "other",
 };
 
 
@@ -1462,6 +1514,35 @@ export interface HPLCVariable extends DiscreteMeasuredVariable {
 
 
 /**
+ * Physiological response variable from discrete field samples (e.g., organism growth rates, calcification rates, gene expression from bottle or tissue samples collected in the field).
+ */
+export interface DiscretePhysiologicalVariable extends DiscreteMeasuredVariable, MeasuredPhysiologicalFields {
+}
+
+
+/**
+ * Physiological response variable from continuous autonomous field sensors (e.g., respiration rates from deployed oxygen consumption monitors, heart rate from bio-loggers).
+ */
+export interface ContinuousPhysiologicalVariable extends ContinuousMeasuredVariable, MeasuredPhysiologicalFields {
+}
+
+
+/**
+ * Socioeconomic variable for social and economic data such as survey responses, ecosystem service valuations, or text analysis. Extends InSituVariable to inherit method_reference and measurement_researcher, but does NOT include QCFields, instrument details, or calibration.
+ */
+export interface SocioeconomicVariable extends InSituVariable {
+    /** Whether this variable captures quantitative (numerical) or qualitative (categorical/textual) data. */
+    quantitative_or_qualitative: string,
+    /** The type of social science study this variable comes from. */
+    social_study_type?: string,
+    /** Custom study type description when "other" is selected. */
+    social_study_type_custom?: string,
+    /** Time period and location description for the social study (e.g., "2023-2024, coastal communities in Maine, USA"). */
+    social_study_site_characterization?: string,
+}
+
+
+/**
  * Sample preservation information for DIC and TA measurements. Reference: OAPMetadata XSD variables.xsd - sample_preservation
  */
 export interface SamplePreservation {
@@ -1529,6 +1610,37 @@ export interface MeasuredSedimentFields {
     sediment_sampling_depth: string,
     /** Water depth where sediment was collected. If provided as a variable (recommended), please list the column header name here. */
     sediment_sampling_water_depth: string,
+}
+
+
+/**
+ * Fields applied to all measured physiological variable types (discrete and continuous). Captures biological subject identification and experimental design information for organism response field studies.
+ */
+export interface MeasuredPhysiologicalFields {
+    /** Taxonomy (species, genus, or community) being studied (e.g., Crassostrea gigas, coral reef community). */
+    biological_subject: string,
+    /** Species reference code from a taxonomic database (e.g., WoRMS AphiaID 140656, ITIS TSN 79861). */
+    species_identification_code?: string,
+    /** Which taxonomic code system the identification code refers to. */
+    taxonomic_code_system?: string,
+    /** Life stage of the organism at time of measurement. */
+    life_stage?: string,
+    /** Custom life stage description when "other" is selected. */
+    life_stage_custom?: string,
+    /** Target pCO2 or alkalinity levels for the manipulation experiment (e.g., "400, 800, 1200 uatm pCO2"). */
+    targeted_acidity_levels?: string,
+    /** How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition). */
+    manipulation_method?: string,
+    /** Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site). */
+    experiment_location?: string,
+    /** Where the biological subjects were collected from. */
+    subject_collection_location?: string,
+    /** Start of the experimental treatment period (UTC). */
+    treatment_start_datetime?: string,
+    /** End of the experimental treatment period (UTC). */
+    treatment_end_datetime?: string,
+    /** Any additional information about the physiological experiment. */
+    additional_details?: string,
 }
 
 

--- a/project/typescript/oae_data_protocol.ts
+++ b/project/typescript/oae_data_protocol.ts
@@ -1627,20 +1627,6 @@ export interface MeasuredPhysiologicalFields {
     life_stage?: string,
     /** Custom life stage description when "other" is selected. */
     life_stage_custom?: string,
-    /** Target pCO2 or alkalinity levels for the manipulation experiment (e.g., "400, 800, 1200 uatm pCO2"). */
-    targeted_acidity_levels?: string,
-    /** How ocean chemistry conditions were manipulated (e.g., CO2 bubbling, acid addition, alkalinity addition). */
-    manipulation_method?: string,
-    /** Where the experiment was carried out (e.g., outdoor mesocosm facility, natural field site). */
-    experiment_location?: string,
-    /** Where the biological subjects were collected from. */
-    subject_collection_location?: string,
-    /** Start of the experimental treatment period (UTC). */
-    treatment_start_datetime?: string,
-    /** End of the experimental treatment period (UTC). */
-    treatment_end_datetime?: string,
-    /** Any additional information about the physiological experiment. */
-    additional_details?: string,
 }
 
 

--- a/src/docs/files/Variables/index.md
+++ b/src/docs/files/Variables/index.md
@@ -13,20 +13,24 @@ graph LR
     MV("`*MeasuredVariable*
     (abstract)`")
     NMV["NonMeasuredVariable"]
+    SEV["SocioeconomicVariable"]
     CV["CalculatedVariable"]
     DM["DiscreteMeasuredVariable"]
     CM["ContinuousMeasuredVariable"]
     DPH["`DiscretePHVariable
     DiscreteTAVariable
     DiscreteDICVariable
+    DiscretePhysiologicalVariable
     *…and others*`"]
     CPH["`ContinuousPHVariable
     ContinuousTAVariable
     ContinuousDICVariable
+    ContinuousPhysiologicalVariable
     *…and others*`"]
 
     V --> NMV
     V --> ISV
+    ISV --> SEV
     ISV --> CV
     ISV --> MV
     MV --> DM
@@ -38,7 +42,7 @@ graph LR
     classDef concrete fill:#e0e8f0,stroke:#4F656A
     classDef leaf fill:#d0e8d0,stroke:#4F656A
     class V,ISV,MV abstract
-    class NMV,CV,DPH,CPH concrete
+    class NMV,SEV,CV,DPH,CPH concrete
     class DM,CM leaf
 ```
 
@@ -62,6 +66,8 @@ What kind of measurement is this?
 | `co2` | CO₂ measurement variables  | pCO₂, fCO₂, xCO₂ |
 | `sediment` | Sediment variable          | Sediment core measurements |
 | `hplc` | HPLC pigments              | Chlorophyll, carotenoids |
+| `physiological` | Physiological response | Organism growth rates, calcification |
+| `socioeconomic` | Social/economic data   | Survey responses, ecosystem valuations |
 | `other` | Generic variable           | Temperature, salinity, nutrients |
 | `non_measured` | Contextual data            | Station ID, timestamps, coordinates |
 
@@ -94,9 +100,13 @@ How were measurements collected? (Only for `measured` genesis)
 | `dic` | `measured` | `discrete` | [DiscreteDICVariable](../DiscreteDICVariable.md) |
 | `dic` | `measured` | `continuous` | [ContinuousDICVariable](../ContinuousDICVariable.md) |
 | `co2` | `measured` | `discrete` | [DiscreteCO2Variable](../DiscreteCO2Variable.md) |
+| `co2` | `measured` | `continuous` | [ContinuousCO2Variable](../ContinuousCO2Variable.md) |
 | `sediment` | `measured` | `discrete` | [DiscreteSedimentVariable](../DiscreteSedimentVariable.md) |
 | `sediment` | `measured` | `continuous` | [ContinuousSedimentVariable](../ContinuousSedimentVariable.md) |
 | `hplc` | `measured` | `discrete` | [HPLCVariable](../HPLCVariable.md) |
+| `physiological` | `measured` | `discrete` | [DiscretePhysiologicalVariable](../DiscretePhysiologicalVariable.md) |
+| `physiological` | `measured` | `continuous` | [ContinuousPhysiologicalVariable](../ContinuousPhysiologicalVariable.md) |
+| `socioeconomic` | `measured` | — | [SocioeconomicVariable](../SocioeconomicVariable.md) |
 | `other` | `measured` | `discrete` | [DiscreteMeasuredVariable](../DiscreteMeasuredVariable.md) |
 | `other` | `measured` | `continuous` | [ContinuousMeasuredVariable](../ContinuousMeasuredVariable.md) |
 | Any except `non_measured` | `calculated` | — | [CalculatedVariable](../CalculatedVariable.md) |
@@ -138,55 +148,23 @@ Adds calculation provenance:
 
 - `calculation_method_and_parameters` — software, input variables, constants used
 
-### Chemistry-Specific Classes
+### Type-Specific Fields (Traits / Mixins)
 
-Each chemistry type (pH, TA, DIC, CO₂) adds specialized fields:
+Many measured variables (either discrete or continuous) inherit additional fields based on their `variable_type` that are
+always present whether the specific variable is discrete or continuous. In these instances, we use LinkML's [mixin](https://linkml.io/linkml/schemas/inheritance.html#mixin-classes-and-slots)
+feature to allow for trait-like composability of these fields into both the corresponding DiscreteVariable and
+ContinuousVariable classes for that `variable_type`.
 
-- **pH**: measurement temperature, temperature correction method, reported temperature, dye calibration
-- **TA**: titration type, cell type, curve fitting method, CRM calibration
-- **DIC**: CRM calibration, sample preservation
-- **CO₂**: storage method, headspace volume, measurement temperature, gas detector calibration
+| Variable Type | Mixin                                                            |
+|---------------|------------------------------------------------------------------|
+| `pH` | [MeasuredPHFields](../MeasuredPHFields.md)                       |
+| `ta` | [MeasuredTAFields](../MeasuredTAFields.md)                       |
+| `dic` | [MeasuredDICFields](../MeasuredDICFields.md)                     |
+| `co2` | [MeasuredCO2Fields](../MeasuredCO2Fields.md)                     |
+| `sediment` | [MeasuredSedimentFields](../MeasuredSedimentFields.md)           |
+| `physiological` | [MeasuredPhysiologicalFields](../MeasuredPhysiologicalFields.md) |
+| `other` | —                                                                |
 
-## Example: pH Variable
-
-```json
-{
-  "schema_class": "DiscretePHVariable",
-  "variable_type": "pH",
-  "genesis": "measured",
-  "sampling": "discrete",
-  "dataset_variable_name": "pH_total",
-  "long_name": "pH on total scale at in-situ temperature",
-  "units": "pH units",
-  "sampling_method": "Niskin bottle",
-  "analyzing_method": "Spectrophotometric, purified m-cresol purple",
-  "observation_type": "profile",
-  "measurement_temperature": "25",
-  "ph_reported_temperature": "in-situ temperature"
-}
-```
-
-## Example: Calculated Variable
-
-```json
-{
-  "schema_class": "CalculatedVariable",
-  "variable_type": "ta",
-  "genesis": "calculated",
-  "dataset_variable_name": "ta_calc",
-  "long_name": "Total alkalinity calculated from salinity regression",
-  "units": "umol/kg",
-  "calculation_method_and_parameters": "Lee et al. 2006 salinity-TA relationship"
-}
-```
-
-## Example: Contextual Variable
-
-```json
-{
-  "schema_class": "NonMeasuredVariable",
-  "variable_type": "non_measured",
-  "dataset_variable_name": "expocode",
-  "long_name": "Cruise expedition code"
-}
-```
+Leaf classes (e.g., [DiscretePHVariable](../DiscretePHVariable.md), [DiscreteTAVariable](../DiscreteTAVariable.md)) may
+add further type-specific fields as well. For a comprehensive list of all required and optional fields please refer
+to the individual class pages linked in the [mapping table](#selection-schema-class-mapping) above.

--- a/src/oae_data_protocol/datamodel/oae_data_protocol.py
+++ b/src/oae_data_protocol/datamodel/oae_data_protocol.py
@@ -1,5 +1,5 @@
 # Auto generated from oae_data_protocol.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-04-09T20:11:07
+# Generation date: 2026-05-24T19:36:26
 # Schema: OAEDataSchema
 #
 # id: https://schema.oaedata.org/OAEDataSchema
@@ -2330,6 +2330,236 @@ class HPLCVariable(DiscreteMeasuredVariable):
 
 
 @dataclass(repr=False)
+class DiscretePhysiologicalVariable(DiscreteMeasuredVariable):
+    """
+    Physiological response variable from discrete field samples (e.g., organism growth rates, calcification rates,
+    gene expression from bottle or tissue samples collected in the field).
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = OAE["DiscretePhysiologicalVariable"]
+    class_class_curie: ClassVar[str] = "oae:DiscretePhysiologicalVariable"
+    class_name: ClassVar[str] = "DiscretePhysiologicalVariable"
+    class_model_uri: ClassVar[URIRef] = OAE.DiscretePhysiologicalVariable
+
+    schema_class: str = None
+    dataset_variable_name: str = None
+    long_name: str = None
+    units: str = None
+    analyzing_instrument: Union[dict, "AnalyzingInstrument"] = None
+    sampling_method: str = None
+    analyzing_method: str = None
+    observation_type: Union[str, "ObservationType"] = None
+    sampling_instrument_type: Union[str, "SamplingInstrumentType"] = None
+    qc_steps_taken: str = None
+    uncertainty: str = None
+    uncertainty_definition: str = None
+    missing_value_indicators: str = None
+    genesis: str = None
+    sampling: str = None
+    biological_subject: str = None
+    variable_type: Optional[str] = None
+    species_identification_code: Optional[str] = None
+    taxonomic_code_system: Optional[Union[str, "TaxonomicCodeSystem"]] = None
+    life_stage: Optional[Union[str, "LifeStage"]] = None
+    life_stage_custom: Optional[str] = None
+    targeted_acidity_levels: Optional[str] = None
+    manipulation_method: Optional[str] = None
+    experiment_location: Optional[str] = None
+    subject_collection_location: Optional[str] = None
+    treatment_start_datetime: Optional[Union[str, XSDDateTime]] = None
+    treatment_end_datetime: Optional[Union[str, XSDDateTime]] = None
+    additional_details: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.biological_subject):
+            self.MissingRequiredField("biological_subject")
+        if not isinstance(self.biological_subject, str):
+            self.biological_subject = str(self.biological_subject)
+
+        if self.variable_type is not None and not isinstance(self.variable_type, str):
+            self.variable_type = str(self.variable_type)
+
+        if self.species_identification_code is not None and not isinstance(self.species_identification_code, str):
+            self.species_identification_code = str(self.species_identification_code)
+
+        if self.taxonomic_code_system is not None and not isinstance(self.taxonomic_code_system, TaxonomicCodeSystem):
+            self.taxonomic_code_system = TaxonomicCodeSystem(self.taxonomic_code_system)
+
+        if self.life_stage is not None and not isinstance(self.life_stage, LifeStage):
+            self.life_stage = LifeStage(self.life_stage)
+
+        if self.life_stage_custom is not None and not isinstance(self.life_stage_custom, str):
+            self.life_stage_custom = str(self.life_stage_custom)
+
+        if self.targeted_acidity_levels is not None and not isinstance(self.targeted_acidity_levels, str):
+            self.targeted_acidity_levels = str(self.targeted_acidity_levels)
+
+        if self.manipulation_method is not None and not isinstance(self.manipulation_method, str):
+            self.manipulation_method = str(self.manipulation_method)
+
+        if self.experiment_location is not None and not isinstance(self.experiment_location, str):
+            self.experiment_location = str(self.experiment_location)
+
+        if self.subject_collection_location is not None and not isinstance(self.subject_collection_location, str):
+            self.subject_collection_location = str(self.subject_collection_location)
+
+        if self.treatment_start_datetime is not None and not isinstance(self.treatment_start_datetime, XSDDateTime):
+            self.treatment_start_datetime = XSDDateTime(self.treatment_start_datetime)
+
+        if self.treatment_end_datetime is not None and not isinstance(self.treatment_end_datetime, XSDDateTime):
+            self.treatment_end_datetime = XSDDateTime(self.treatment_end_datetime)
+
+        if self.additional_details is not None and not isinstance(self.additional_details, str):
+            self.additional_details = str(self.additional_details)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.unknown_schema_class):
+            self.MissingRequiredField("unknown_schema_class")
+        self.unknown_schema_class = str(self.class_name)
+
+
+@dataclass(repr=False)
+class ContinuousPhysiologicalVariable(ContinuousMeasuredVariable):
+    """
+    Physiological response variable from continuous autonomous field sensors (e.g., respiration rates from deployed
+    oxygen consumption monitors, heart rate from bio-loggers).
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = OAE["ContinuousPhysiologicalVariable"]
+    class_class_curie: ClassVar[str] = "oae:ContinuousPhysiologicalVariable"
+    class_name: ClassVar[str] = "ContinuousPhysiologicalVariable"
+    class_model_uri: ClassVar[URIRef] = OAE.ContinuousPhysiologicalVariable
+
+    schema_class: str = None
+    dataset_variable_name: str = None
+    long_name: str = None
+    units: str = None
+    analyzing_instrument: Union[dict, "AnalyzingInstrument"] = None
+    sampling_method: str = None
+    analyzing_method: str = None
+    observation_type: Union[str, "ObservationType"] = None
+    sampling_instrument_type: Union[str, "SamplingInstrumentType"] = None
+    qc_steps_taken: str = None
+    uncertainty: str = None
+    uncertainty_definition: str = None
+    missing_value_indicators: str = None
+    genesis: str = None
+    raw_data_calculation_method: str = None
+    sampling: str = None
+    biological_subject: str = None
+    variable_type: Optional[str] = None
+    species_identification_code: Optional[str] = None
+    taxonomic_code_system: Optional[Union[str, "TaxonomicCodeSystem"]] = None
+    life_stage: Optional[Union[str, "LifeStage"]] = None
+    life_stage_custom: Optional[str] = None
+    targeted_acidity_levels: Optional[str] = None
+    manipulation_method: Optional[str] = None
+    experiment_location: Optional[str] = None
+    subject_collection_location: Optional[str] = None
+    treatment_start_datetime: Optional[Union[str, XSDDateTime]] = None
+    treatment_end_datetime: Optional[Union[str, XSDDateTime]] = None
+    additional_details: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.biological_subject):
+            self.MissingRequiredField("biological_subject")
+        if not isinstance(self.biological_subject, str):
+            self.biological_subject = str(self.biological_subject)
+
+        if self.variable_type is not None and not isinstance(self.variable_type, str):
+            self.variable_type = str(self.variable_type)
+
+        if self.species_identification_code is not None and not isinstance(self.species_identification_code, str):
+            self.species_identification_code = str(self.species_identification_code)
+
+        if self.taxonomic_code_system is not None and not isinstance(self.taxonomic_code_system, TaxonomicCodeSystem):
+            self.taxonomic_code_system = TaxonomicCodeSystem(self.taxonomic_code_system)
+
+        if self.life_stage is not None and not isinstance(self.life_stage, LifeStage):
+            self.life_stage = LifeStage(self.life_stage)
+
+        if self.life_stage_custom is not None and not isinstance(self.life_stage_custom, str):
+            self.life_stage_custom = str(self.life_stage_custom)
+
+        if self.targeted_acidity_levels is not None and not isinstance(self.targeted_acidity_levels, str):
+            self.targeted_acidity_levels = str(self.targeted_acidity_levels)
+
+        if self.manipulation_method is not None and not isinstance(self.manipulation_method, str):
+            self.manipulation_method = str(self.manipulation_method)
+
+        if self.experiment_location is not None and not isinstance(self.experiment_location, str):
+            self.experiment_location = str(self.experiment_location)
+
+        if self.subject_collection_location is not None and not isinstance(self.subject_collection_location, str):
+            self.subject_collection_location = str(self.subject_collection_location)
+
+        if self.treatment_start_datetime is not None and not isinstance(self.treatment_start_datetime, XSDDateTime):
+            self.treatment_start_datetime = XSDDateTime(self.treatment_start_datetime)
+
+        if self.treatment_end_datetime is not None and not isinstance(self.treatment_end_datetime, XSDDateTime):
+            self.treatment_end_datetime = XSDDateTime(self.treatment_end_datetime)
+
+        if self.additional_details is not None and not isinstance(self.additional_details, str):
+            self.additional_details = str(self.additional_details)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.unknown_schema_class):
+            self.MissingRequiredField("unknown_schema_class")
+        self.unknown_schema_class = str(self.class_name)
+
+
+@dataclass(repr=False)
+class SocioeconomicVariable(InSituVariable):
+    """
+    Socioeconomic variable for social and economic data such as survey responses, ecosystem service valuations, or
+    text analysis. Extends InSituVariable to inherit method_reference and measurement_researcher, but does NOT include
+    QCFields, instrument details, or calibration.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = OAE["SocioeconomicVariable"]
+    class_class_curie: ClassVar[str] = "oae:SocioeconomicVariable"
+    class_name: ClassVar[str] = "SocioeconomicVariable"
+    class_model_uri: ClassVar[URIRef] = OAE.SocioeconomicVariable
+
+    schema_class: str = None
+    dataset_variable_name: str = None
+    long_name: str = None
+    genesis: Union[str, "GenesisType"] = None
+    units: str = None
+    quantitative_or_qualitative: Union[str, "QuantitativeQualitative"] = None
+    social_study_type: Optional[Union[str, "SocialStudyType"]] = None
+    social_study_type_custom: Optional[str] = None
+    social_study_site_characterization: Optional[str] = None
+    variable_type: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.quantitative_or_qualitative):
+            self.MissingRequiredField("quantitative_or_qualitative")
+        if not isinstance(self.quantitative_or_qualitative, QuantitativeQualitative):
+            self.quantitative_or_qualitative = QuantitativeQualitative(self.quantitative_or_qualitative)
+
+        if self.social_study_type is not None and not isinstance(self.social_study_type, SocialStudyType):
+            self.social_study_type = SocialStudyType(self.social_study_type)
+
+        if self.social_study_type_custom is not None and not isinstance(self.social_study_type_custom, str):
+            self.social_study_type_custom = str(self.social_study_type_custom)
+
+        if self.social_study_site_characterization is not None and not isinstance(self.social_study_site_characterization, str):
+            self.social_study_site_characterization = str(self.social_study_site_characterization)
+
+        if self.variable_type is not None and not isinstance(self.variable_type, str):
+            self.variable_type = str(self.variable_type)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.unknown_schema_class):
+            self.MissingRequiredField("unknown_schema_class")
+        self.unknown_schema_class = str(self.class_name)
+
+
+@dataclass(repr=False)
 class SamplePreservation(YAMLRoot):
     """
     Sample preservation information for DIC and TA measurements. Reference: OAPMetadata XSD variables.xsd -
@@ -2505,6 +2735,74 @@ class MeasuredSedimentFields(YAMLRoot):
             self.MissingRequiredField("sediment_sampling_water_depth")
         if not isinstance(self.sediment_sampling_water_depth, str):
             self.sediment_sampling_water_depth = str(self.sediment_sampling_water_depth)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class MeasuredPhysiologicalFields(YAMLRoot):
+    """
+    Fields applied to all measured physiological variable types (discrete and continuous). Captures biological subject
+    identification and experimental design information for organism response field studies.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = OAE["MeasuredPhysiologicalFields"]
+    class_class_curie: ClassVar[str] = "oae:MeasuredPhysiologicalFields"
+    class_name: ClassVar[str] = "MeasuredPhysiologicalFields"
+    class_model_uri: ClassVar[URIRef] = OAE.MeasuredPhysiologicalFields
+
+    biological_subject: str = None
+    species_identification_code: Optional[str] = None
+    taxonomic_code_system: Optional[Union[str, "TaxonomicCodeSystem"]] = None
+    life_stage: Optional[Union[str, "LifeStage"]] = None
+    life_stage_custom: Optional[str] = None
+    targeted_acidity_levels: Optional[str] = None
+    manipulation_method: Optional[str] = None
+    experiment_location: Optional[str] = None
+    subject_collection_location: Optional[str] = None
+    treatment_start_datetime: Optional[Union[str, XSDDateTime]] = None
+    treatment_end_datetime: Optional[Union[str, XSDDateTime]] = None
+    additional_details: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.biological_subject):
+            self.MissingRequiredField("biological_subject")
+        if not isinstance(self.biological_subject, str):
+            self.biological_subject = str(self.biological_subject)
+
+        if self.species_identification_code is not None and not isinstance(self.species_identification_code, str):
+            self.species_identification_code = str(self.species_identification_code)
+
+        if self.taxonomic_code_system is not None and not isinstance(self.taxonomic_code_system, TaxonomicCodeSystem):
+            self.taxonomic_code_system = TaxonomicCodeSystem(self.taxonomic_code_system)
+
+        if self.life_stage is not None and not isinstance(self.life_stage, LifeStage):
+            self.life_stage = LifeStage(self.life_stage)
+
+        if self.life_stage_custom is not None and not isinstance(self.life_stage_custom, str):
+            self.life_stage_custom = str(self.life_stage_custom)
+
+        if self.targeted_acidity_levels is not None and not isinstance(self.targeted_acidity_levels, str):
+            self.targeted_acidity_levels = str(self.targeted_acidity_levels)
+
+        if self.manipulation_method is not None and not isinstance(self.manipulation_method, str):
+            self.manipulation_method = str(self.manipulation_method)
+
+        if self.experiment_location is not None and not isinstance(self.experiment_location, str):
+            self.experiment_location = str(self.experiment_location)
+
+        if self.subject_collection_location is not None and not isinstance(self.subject_collection_location, str):
+            self.subject_collection_location = str(self.subject_collection_location)
+
+        if self.treatment_start_datetime is not None and not isinstance(self.treatment_start_datetime, XSDDateTime):
+            self.treatment_start_datetime = XSDDateTime(self.treatment_start_datetime)
+
+        if self.treatment_end_datetime is not None and not isinstance(self.treatment_end_datetime, XSDDateTime):
+            self.treatment_end_datetime = XSDDateTime(self.treatment_end_datetime)
+
+        if self.additional_details is not None and not isinstance(self.additional_details, str):
+            self.additional_details = str(self.additional_details)
 
         super().__post_init__(**kwargs)
 
@@ -4923,6 +5221,12 @@ class VariableType(EnumDefinitionImpl):
     hplc = PermissibleValue(
         text="hplc",
         description="HPLC pigment analysis — use with HPLCVariable (always discrete, always measured)")
+    physiological = PermissibleValue(
+        text="physiological",
+        description="""Physiological response variable — organism response data from field experiments. Use with Discrete/ContinuousPhysiologicalVariable or CalculatedVariable.""")
+    socioeconomic = PermissibleValue(
+        text="socioeconomic",
+        description="""Socioeconomic variable — social and economic data. Use only with SocioeconomicVariable. Does not include QC fields.""")
     other = PermissibleValue(
         text="other",
         description="""Any directly measured or calculated variable that does not fall into a specific category above (e.g., temperature, salinity, conductivity, pressure, fluorescence). Use with DiscreteMeasuredVariable, ContinuousMeasuredVariable, or CalculatedVariable.""")
@@ -4992,6 +5296,78 @@ class ConcentrationBasis(EnumDefinitionImpl):
     _defn = EnumDefinition(
         name="ConcentrationBasis",
         description="Whether concentration measurements are expressed per unit volume or per unit mass.",
+    )
+
+class TaxonomicCodeSystem(EnumDefinitionImpl):
+    """
+    Taxonomic code system used for species identification.
+    """
+    itis = PermissibleValue(
+        text="itis",
+        description="Integrated Taxonomic Information System")
+    worms = PermissibleValue(
+        text="worms",
+        description="World Register of Marine Species")
+    col = PermissibleValue(
+        text="col",
+        description="Catalogue of Life")
+    pbdb = PermissibleValue(
+        text="pbdb",
+        description="Paleobiology Database")
+
+    _defn = EnumDefinition(
+        name="TaxonomicCodeSystem",
+        description="Taxonomic code system used for species identification.",
+    )
+
+class LifeStage(EnumDefinitionImpl):
+    """
+    Life stage of the biological subject.
+    """
+    egg = PermissibleValue(text="egg")
+    embryo = PermissibleValue(text="embryo")
+    larva = PermissibleValue(text="larva")
+    juvenile = PermissibleValue(text="juvenile")
+    adult = PermissibleValue(text="adult")
+    other = PermissibleValue(text="other")
+
+    _defn = EnumDefinition(
+        name="LifeStage",
+        description="Life stage of the biological subject.",
+    )
+
+class QuantitativeQualitative(EnumDefinitionImpl):
+    """
+    Whether the socioeconomic data is quantitative or qualitative.
+    """
+    quantitative = PermissibleValue(text="quantitative")
+    qualitative = PermissibleValue(text="qualitative")
+
+    _defn = EnumDefinition(
+        name="QuantitativeQualitative",
+        description="Whether the socioeconomic data is quantitative or qualitative.",
+    )
+
+class SocialStudyType(EnumDefinitionImpl):
+    """
+    Type of social study conducted.
+    """
+    public_perception_survey = PermissibleValue(
+        text="public_perception_survey",
+        description="Public perception survey")
+    ecosystem_service_valuation_survey = PermissibleValue(
+        text="ecosystem_service_valuation_survey",
+        description="Ecosystem service valuation survey")
+    text_analysis = PermissibleValue(
+        text="text_analysis",
+        description="Text analysis")
+    other = PermissibleValue(
+        text="other",
+        description="Other study type")
+
+    _defn = EnumDefinition(
+        name="SocialStudyType",
+        description="Type of social study conducted.",
     )
 
 class SamplingInstrumentType(EnumDefinitionImpl):
@@ -5635,6 +6011,18 @@ slots.hPLCVariable__hplc_lab = Slot(uri=OAE.hplc_lab, name="hPLCVariable__hplc_l
 slots.hPLCVariable__hplc_lab_technician = Slot(uri=OAE.hplc_lab_technician, name="hPLCVariable__hplc_lab_technician", curie=OAE.curie('hplc_lab_technician'),
                    model_uri=OAE.hPLCVariable__hplc_lab_technician, domain=None, range=Optional[str])
 
+slots.socioeconomicVariable__quantitative_or_qualitative = Slot(uri=OAE.quantitative_or_qualitative, name="socioeconomicVariable__quantitative_or_qualitative", curie=OAE.curie('quantitative_or_qualitative'),
+                   model_uri=OAE.socioeconomicVariable__quantitative_or_qualitative, domain=None, range=Union[str, "QuantitativeQualitative"])
+
+slots.socioeconomicVariable__social_study_type = Slot(uri=OAE.social_study_type, name="socioeconomicVariable__social_study_type", curie=OAE.curie('social_study_type'),
+                   model_uri=OAE.socioeconomicVariable__social_study_type, domain=None, range=Optional[Union[str, "SocialStudyType"]])
+
+slots.socioeconomicVariable__social_study_type_custom = Slot(uri=OAE.social_study_type_custom, name="socioeconomicVariable__social_study_type_custom", curie=OAE.curie('social_study_type_custom'),
+                   model_uri=OAE.socioeconomicVariable__social_study_type_custom, domain=None, range=Optional[str])
+
+slots.socioeconomicVariable__social_study_site_characterization = Slot(uri=OAE.social_study_site_characterization, name="socioeconomicVariable__social_study_site_characterization", curie=OAE.curie('social_study_site_characterization'),
+                   model_uri=OAE.socioeconomicVariable__social_study_site_characterization, domain=None, range=Optional[str])
+
 slots.samplePreservation__preservative = Slot(uri=OAE.preservative, name="samplePreservation__preservative", curie=OAE.curie('preservative'),
                    model_uri=OAE.samplePreservation__preservative, domain=None, range=str)
 
@@ -5661,6 +6049,42 @@ slots.measuredSedimentFields__sediment_sampling_depth = Slot(uri=OAE.sediment_sa
 
 slots.measuredSedimentFields__sediment_sampling_water_depth = Slot(uri=OAE.sediment_sampling_water_depth, name="measuredSedimentFields__sediment_sampling_water_depth", curie=OAE.curie('sediment_sampling_water_depth'),
                    model_uri=OAE.measuredSedimentFields__sediment_sampling_water_depth, domain=None, range=str)
+
+slots.measuredPhysiologicalFields__biological_subject = Slot(uri=OAE.biological_subject, name="measuredPhysiologicalFields__biological_subject", curie=OAE.curie('biological_subject'),
+                   model_uri=OAE.measuredPhysiologicalFields__biological_subject, domain=None, range=str)
+
+slots.measuredPhysiologicalFields__species_identification_code = Slot(uri=OAE.species_identification_code, name="measuredPhysiologicalFields__species_identification_code", curie=OAE.curie('species_identification_code'),
+                   model_uri=OAE.measuredPhysiologicalFields__species_identification_code, domain=None, range=Optional[str])
+
+slots.measuredPhysiologicalFields__taxonomic_code_system = Slot(uri=OAE.taxonomic_code_system, name="measuredPhysiologicalFields__taxonomic_code_system", curie=OAE.curie('taxonomic_code_system'),
+                   model_uri=OAE.measuredPhysiologicalFields__taxonomic_code_system, domain=None, range=Optional[Union[str, "TaxonomicCodeSystem"]])
+
+slots.measuredPhysiologicalFields__life_stage = Slot(uri=OAE.life_stage, name="measuredPhysiologicalFields__life_stage", curie=OAE.curie('life_stage'),
+                   model_uri=OAE.measuredPhysiologicalFields__life_stage, domain=None, range=Optional[Union[str, "LifeStage"]])
+
+slots.measuredPhysiologicalFields__life_stage_custom = Slot(uri=OAE.life_stage_custom, name="measuredPhysiologicalFields__life_stage_custom", curie=OAE.curie('life_stage_custom'),
+                   model_uri=OAE.measuredPhysiologicalFields__life_stage_custom, domain=None, range=Optional[str])
+
+slots.measuredPhysiologicalFields__targeted_acidity_levels = Slot(uri=OAE.targeted_acidity_levels, name="measuredPhysiologicalFields__targeted_acidity_levels", curie=OAE.curie('targeted_acidity_levels'),
+                   model_uri=OAE.measuredPhysiologicalFields__targeted_acidity_levels, domain=None, range=Optional[str])
+
+slots.measuredPhysiologicalFields__manipulation_method = Slot(uri=OAE.manipulation_method, name="measuredPhysiologicalFields__manipulation_method", curie=OAE.curie('manipulation_method'),
+                   model_uri=OAE.measuredPhysiologicalFields__manipulation_method, domain=None, range=Optional[str])
+
+slots.measuredPhysiologicalFields__experiment_location = Slot(uri=OAE.experiment_location, name="measuredPhysiologicalFields__experiment_location", curie=OAE.curie('experiment_location'),
+                   model_uri=OAE.measuredPhysiologicalFields__experiment_location, domain=None, range=Optional[str])
+
+slots.measuredPhysiologicalFields__subject_collection_location = Slot(uri=OAE.subject_collection_location, name="measuredPhysiologicalFields__subject_collection_location", curie=OAE.curie('subject_collection_location'),
+                   model_uri=OAE.measuredPhysiologicalFields__subject_collection_location, domain=None, range=Optional[str])
+
+slots.measuredPhysiologicalFields__treatment_start_datetime = Slot(uri=OAE.treatment_start_datetime, name="measuredPhysiologicalFields__treatment_start_datetime", curie=OAE.curie('treatment_start_datetime'),
+                   model_uri=OAE.measuredPhysiologicalFields__treatment_start_datetime, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.measuredPhysiologicalFields__treatment_end_datetime = Slot(uri=OAE.treatment_end_datetime, name="measuredPhysiologicalFields__treatment_end_datetime", curie=OAE.curie('treatment_end_datetime'),
+                   model_uri=OAE.measuredPhysiologicalFields__treatment_end_datetime, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.measuredPhysiologicalFields__additional_details = Slot(uri=OAE.additional_details, name="measuredPhysiologicalFields__additional_details", curie=OAE.curie('additional_details'),
+                   model_uri=OAE.measuredPhysiologicalFields__additional_details, domain=None, range=Optional[str])
 
 slots.measuredCO2Fields__pco2_reported_temperature = Slot(uri=OAE.pco2_reported_temperature, name="measuredCO2Fields__pco2_reported_temperature", curie=OAE.curie('pco2_reported_temperature'),
                    model_uri=OAE.measuredCO2Fields__pco2_reported_temperature, domain=None, range=str)
@@ -6142,6 +6566,15 @@ slots.ContinuousCO2Variable_analyzing_instrument = Slot(uri=OAE.analyzing_instru
 
 slots.HPLCVariable_variable_type = Slot(uri=OAE.variable_type, name="HPLCVariable_variable_type", curie=OAE.curie('variable_type'),
                    model_uri=OAE.HPLCVariable_variable_type, domain=HPLCVariable, range=Optional[str])
+
+slots.DiscretePhysiologicalVariable_variable_type = Slot(uri=OAE.variable_type, name="DiscretePhysiologicalVariable_variable_type", curie=OAE.curie('variable_type'),
+                   model_uri=OAE.DiscretePhysiologicalVariable_variable_type, domain=DiscretePhysiologicalVariable, range=Optional[str])
+
+slots.ContinuousPhysiologicalVariable_variable_type = Slot(uri=OAE.variable_type, name="ContinuousPhysiologicalVariable_variable_type", curie=OAE.curie('variable_type'),
+                   model_uri=OAE.ContinuousPhysiologicalVariable_variable_type, domain=ContinuousPhysiologicalVariable, range=Optional[str])
+
+slots.SocioeconomicVariable_variable_type = Slot(uri=OAE.variable_type, name="SocioeconomicVariable_variable_type", curie=OAE.curie('variable_type'),
+                   model_uri=OAE.SocioeconomicVariable_variable_type, domain=SocioeconomicVariable, range=Optional[str])
 
 slots.Dataset_name = Slot(uri=SCHEMA.name, name="Dataset_name", curie=SCHEMA.curie('name'),
                    model_uri=OAE.Dataset_name, domain=Dataset, range=str)

--- a/src/oae_data_protocol/datamodel/oae_data_protocol.py
+++ b/src/oae_data_protocol/datamodel/oae_data_protocol.py
@@ -1,5 +1,5 @@
 # Auto generated from oae_data_protocol.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-24T19:36:26
+# Generation date: 2026-06-02T09:56:20
 # Schema: OAEDataSchema
 #
 # id: https://schema.oaedata.org/OAEDataSchema
@@ -2363,13 +2363,6 @@ class DiscretePhysiologicalVariable(DiscreteMeasuredVariable):
     taxonomic_code_system: Optional[Union[str, "TaxonomicCodeSystem"]] = None
     life_stage: Optional[Union[str, "LifeStage"]] = None
     life_stage_custom: Optional[str] = None
-    targeted_acidity_levels: Optional[str] = None
-    manipulation_method: Optional[str] = None
-    experiment_location: Optional[str] = None
-    subject_collection_location: Optional[str] = None
-    treatment_start_datetime: Optional[Union[str, XSDDateTime]] = None
-    treatment_end_datetime: Optional[Union[str, XSDDateTime]] = None
-    additional_details: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.biological_subject):
@@ -2391,27 +2384,6 @@ class DiscretePhysiologicalVariable(DiscreteMeasuredVariable):
 
         if self.life_stage_custom is not None and not isinstance(self.life_stage_custom, str):
             self.life_stage_custom = str(self.life_stage_custom)
-
-        if self.targeted_acidity_levels is not None and not isinstance(self.targeted_acidity_levels, str):
-            self.targeted_acidity_levels = str(self.targeted_acidity_levels)
-
-        if self.manipulation_method is not None and not isinstance(self.manipulation_method, str):
-            self.manipulation_method = str(self.manipulation_method)
-
-        if self.experiment_location is not None and not isinstance(self.experiment_location, str):
-            self.experiment_location = str(self.experiment_location)
-
-        if self.subject_collection_location is not None and not isinstance(self.subject_collection_location, str):
-            self.subject_collection_location = str(self.subject_collection_location)
-
-        if self.treatment_start_datetime is not None and not isinstance(self.treatment_start_datetime, XSDDateTime):
-            self.treatment_start_datetime = XSDDateTime(self.treatment_start_datetime)
-
-        if self.treatment_end_datetime is not None and not isinstance(self.treatment_end_datetime, XSDDateTime):
-            self.treatment_end_datetime = XSDDateTime(self.treatment_end_datetime)
-
-        if self.additional_details is not None and not isinstance(self.additional_details, str):
-            self.additional_details = str(self.additional_details)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.unknown_schema_class):
@@ -2454,13 +2426,6 @@ class ContinuousPhysiologicalVariable(ContinuousMeasuredVariable):
     taxonomic_code_system: Optional[Union[str, "TaxonomicCodeSystem"]] = None
     life_stage: Optional[Union[str, "LifeStage"]] = None
     life_stage_custom: Optional[str] = None
-    targeted_acidity_levels: Optional[str] = None
-    manipulation_method: Optional[str] = None
-    experiment_location: Optional[str] = None
-    subject_collection_location: Optional[str] = None
-    treatment_start_datetime: Optional[Union[str, XSDDateTime]] = None
-    treatment_end_datetime: Optional[Union[str, XSDDateTime]] = None
-    additional_details: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.biological_subject):
@@ -2482,27 +2447,6 @@ class ContinuousPhysiologicalVariable(ContinuousMeasuredVariable):
 
         if self.life_stage_custom is not None and not isinstance(self.life_stage_custom, str):
             self.life_stage_custom = str(self.life_stage_custom)
-
-        if self.targeted_acidity_levels is not None and not isinstance(self.targeted_acidity_levels, str):
-            self.targeted_acidity_levels = str(self.targeted_acidity_levels)
-
-        if self.manipulation_method is not None and not isinstance(self.manipulation_method, str):
-            self.manipulation_method = str(self.manipulation_method)
-
-        if self.experiment_location is not None and not isinstance(self.experiment_location, str):
-            self.experiment_location = str(self.experiment_location)
-
-        if self.subject_collection_location is not None and not isinstance(self.subject_collection_location, str):
-            self.subject_collection_location = str(self.subject_collection_location)
-
-        if self.treatment_start_datetime is not None and not isinstance(self.treatment_start_datetime, XSDDateTime):
-            self.treatment_start_datetime = XSDDateTime(self.treatment_start_datetime)
-
-        if self.treatment_end_datetime is not None and not isinstance(self.treatment_end_datetime, XSDDateTime):
-            self.treatment_end_datetime = XSDDateTime(self.treatment_end_datetime)
-
-        if self.additional_details is not None and not isinstance(self.additional_details, str):
-            self.additional_details = str(self.additional_details)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.unknown_schema_class):
@@ -2757,13 +2701,6 @@ class MeasuredPhysiologicalFields(YAMLRoot):
     taxonomic_code_system: Optional[Union[str, "TaxonomicCodeSystem"]] = None
     life_stage: Optional[Union[str, "LifeStage"]] = None
     life_stage_custom: Optional[str] = None
-    targeted_acidity_levels: Optional[str] = None
-    manipulation_method: Optional[str] = None
-    experiment_location: Optional[str] = None
-    subject_collection_location: Optional[str] = None
-    treatment_start_datetime: Optional[Union[str, XSDDateTime]] = None
-    treatment_end_datetime: Optional[Union[str, XSDDateTime]] = None
-    additional_details: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.biological_subject):
@@ -2782,27 +2719,6 @@ class MeasuredPhysiologicalFields(YAMLRoot):
 
         if self.life_stage_custom is not None and not isinstance(self.life_stage_custom, str):
             self.life_stage_custom = str(self.life_stage_custom)
-
-        if self.targeted_acidity_levels is not None and not isinstance(self.targeted_acidity_levels, str):
-            self.targeted_acidity_levels = str(self.targeted_acidity_levels)
-
-        if self.manipulation_method is not None and not isinstance(self.manipulation_method, str):
-            self.manipulation_method = str(self.manipulation_method)
-
-        if self.experiment_location is not None and not isinstance(self.experiment_location, str):
-            self.experiment_location = str(self.experiment_location)
-
-        if self.subject_collection_location is not None and not isinstance(self.subject_collection_location, str):
-            self.subject_collection_location = str(self.subject_collection_location)
-
-        if self.treatment_start_datetime is not None and not isinstance(self.treatment_start_datetime, XSDDateTime):
-            self.treatment_start_datetime = XSDDateTime(self.treatment_start_datetime)
-
-        if self.treatment_end_datetime is not None and not isinstance(self.treatment_end_datetime, XSDDateTime):
-            self.treatment_end_datetime = XSDDateTime(self.treatment_end_datetime)
-
-        if self.additional_details is not None and not isinstance(self.additional_details, str):
-            self.additional_details = str(self.additional_details)
 
         super().__post_init__(**kwargs)
 
@@ -6064,27 +5980,6 @@ slots.measuredPhysiologicalFields__life_stage = Slot(uri=OAE.life_stage, name="m
 
 slots.measuredPhysiologicalFields__life_stage_custom = Slot(uri=OAE.life_stage_custom, name="measuredPhysiologicalFields__life_stage_custom", curie=OAE.curie('life_stage_custom'),
                    model_uri=OAE.measuredPhysiologicalFields__life_stage_custom, domain=None, range=Optional[str])
-
-slots.measuredPhysiologicalFields__targeted_acidity_levels = Slot(uri=OAE.targeted_acidity_levels, name="measuredPhysiologicalFields__targeted_acidity_levels", curie=OAE.curie('targeted_acidity_levels'),
-                   model_uri=OAE.measuredPhysiologicalFields__targeted_acidity_levels, domain=None, range=Optional[str])
-
-slots.measuredPhysiologicalFields__manipulation_method = Slot(uri=OAE.manipulation_method, name="measuredPhysiologicalFields__manipulation_method", curie=OAE.curie('manipulation_method'),
-                   model_uri=OAE.measuredPhysiologicalFields__manipulation_method, domain=None, range=Optional[str])
-
-slots.measuredPhysiologicalFields__experiment_location = Slot(uri=OAE.experiment_location, name="measuredPhysiologicalFields__experiment_location", curie=OAE.curie('experiment_location'),
-                   model_uri=OAE.measuredPhysiologicalFields__experiment_location, domain=None, range=Optional[str])
-
-slots.measuredPhysiologicalFields__subject_collection_location = Slot(uri=OAE.subject_collection_location, name="measuredPhysiologicalFields__subject_collection_location", curie=OAE.curie('subject_collection_location'),
-                   model_uri=OAE.measuredPhysiologicalFields__subject_collection_location, domain=None, range=Optional[str])
-
-slots.measuredPhysiologicalFields__treatment_start_datetime = Slot(uri=OAE.treatment_start_datetime, name="measuredPhysiologicalFields__treatment_start_datetime", curie=OAE.curie('treatment_start_datetime'),
-                   model_uri=OAE.measuredPhysiologicalFields__treatment_start_datetime, domain=None, range=Optional[Union[str, XSDDateTime]])
-
-slots.measuredPhysiologicalFields__treatment_end_datetime = Slot(uri=OAE.treatment_end_datetime, name="measuredPhysiologicalFields__treatment_end_datetime", curie=OAE.curie('treatment_end_datetime'),
-                   model_uri=OAE.measuredPhysiologicalFields__treatment_end_datetime, domain=None, range=Optional[Union[str, XSDDateTime]])
-
-slots.measuredPhysiologicalFields__additional_details = Slot(uri=OAE.additional_details, name="measuredPhysiologicalFields__additional_details", curie=OAE.curie('additional_details'),
-                   model_uri=OAE.measuredPhysiologicalFields__additional_details, domain=None, range=Optional[str])
 
 slots.measuredCO2Fields__pco2_reported_temperature = Slot(uri=OAE.pco2_reported_temperature, name="measuredCO2Fields__pco2_reported_temperature", curie=OAE.curie('pco2_reported_temperature'),
                    model_uri=OAE.measuredCO2Fields__pco2_reported_temperature, domain=None, range=str)

--- a/src/oae_data_protocol/schema/variable.yaml
+++ b/src/oae_data_protocol/schema/variable.yaml
@@ -507,27 +507,71 @@ classes:
 
 
 
-#  # =============================================================================
-#  # Physiological Variable Class
-#  # =============================================================================
-#  PhysiologicalVariable:
-#    description: >-
-#      Physiological response measured variable for organism response data.
-#    is_a: MeasuredVariable
-#    attributes:
-#      # Physiological-specific fields to be added per Excel spec
-#
-#  # =============================================================================
-#  # Socioeconomic Variable Class
-#  # =============================================================================
-#  SocioeconomicVariable:
-#    description: >-
-#      Socioeconomic variable for social and economic data.
-#      Note: Does NOT include QCFields mixin as QC is not applicable.
-#    is_a: InSituVariable
-#    attributes:
-#      # Socioeconomic-specific fields to be added per Excel spec
+  # =============================================================================
+  # Physiological Variable Classes
+  # =============================================================================
+  DiscretePhysiologicalVariable:
+    description: >-
+      Physiological response variable from discrete field samples (e.g.,
+      organism growth rates, calcification rates, gene expression from
+      bottle or tissue samples collected in the field).
+    is_a: DiscreteMeasuredVariable
+    mixins:
+      - MeasuredPhysiologicalFields
+    slot_usage:
+      variable_type:
+        range: string
+        equals_string: "physiological"
 
+  ContinuousPhysiologicalVariable:
+    description: >-
+      Physiological response variable from continuous autonomous field
+      sensors (e.g., respiration rates from deployed oxygen consumption
+      monitors, heart rate from bio-loggers).
+    is_a: ContinuousMeasuredVariable
+    mixins:
+      - MeasuredPhysiologicalFields
+    slot_usage:
+      variable_type:
+        range: string
+        equals_string: "physiological"
+
+  # =============================================================================
+  # Socioeconomic Variable Class
+  # =============================================================================
+  SocioeconomicVariable:
+    description: >-
+      Socioeconomic variable for social and economic data such as survey
+      responses, ecosystem service valuations, or text analysis. Extends
+      InSituVariable to inherit method_reference and measurement_researcher,
+      but does NOT include QCFields, instrument details, or calibration.
+    is_a: InSituVariable
+    slot_usage:
+      variable_type:
+        range: string
+        equals_string: "socioeconomic"
+    attributes:
+      quantitative_or_qualitative:
+        title: Quantitative or Qualitative
+        description: >-
+          Whether this variable captures quantitative (numerical) or
+          qualitative (categorical/textual) data.
+        range: QuantitativeQualitative
+        required: true
+      social_study_type:
+        title: Social Study Type
+        description: The type of social science study this variable comes from.
+        range: SocialStudyType
+      social_study_type_custom:
+        title: Social Study Type (custom)
+        description: Custom study type description when "other" is selected.
+        range: string
+      social_study_site_characterization:
+        title: Study Site Characterization
+        description: >-
+          Time period and location description for the social study
+          (e.g., "2023-2024, coastal communities in Maine, USA").
+        range: string
 
   # =============================================================================
   # Supporting Classes for Variables
@@ -621,6 +665,73 @@ classes:
         range: string
         required: true
 
+  MeasuredPhysiologicalFields:
+    mixin: true
+    description: >-
+      Fields applied to all measured physiological variable types (discrete
+      and continuous). Captures biological subject identification and
+      experimental design information for organism response field studies.
+    attributes:
+      biological_subject:
+        title: Biological Subject
+        description: >-
+          Taxonomy (species, genus, or community) being studied
+          (e.g., Crassostrea gigas, coral reef community).
+        range: string
+        required: true
+      species_identification_code:
+        title: Species Identification Code
+        description: >-
+          Species reference code from a taxonomic database (e.g., WoRMS
+          AphiaID 140656, ITIS TSN 79861).
+        range: string
+      taxonomic_code_system:
+        title: Taxonomic Code System
+        description: Which taxonomic code system the identification code refers to.
+        range: TaxonomicCodeSystem
+      life_stage:
+        title: Life Stage
+        description: Life stage of the organism at time of measurement.
+        range: LifeStage
+      life_stage_custom:
+        title: Life Stage (custom)
+        description: Custom life stage description when "other" is selected.
+        range: string
+      targeted_acidity_levels:
+        title: Targeted Acidity or Alkalinity Levels
+        description: >-
+          Target pCO2 or alkalinity levels for the manipulation experiment
+          (e.g., "400, 800, 1200 uatm pCO2").
+        range: string
+      manipulation_method:
+        title: Manipulation Method
+        description: >-
+          How ocean chemistry conditions were manipulated (e.g., CO2
+          bubbling, acid addition, alkalinity addition).
+        range: string
+      experiment_location:
+        title: Experiment Location
+        description: >-
+          Where the experiment was carried out (e.g., outdoor mesocosm
+          facility, natural field site).
+        range: string
+      subject_collection_location:
+        title: Subject Collection Location
+        description: Where the biological subjects were collected from.
+        range: string
+      treatment_start_datetime:
+        title: Treatment Start Date/Time
+        description: Start of the experimental treatment period (UTC).
+        range: datetime
+      treatment_end_datetime:
+        title: Treatment End Date/Time
+        description: End of the experimental treatment period (UTC).
+        range: datetime
+      additional_details:
+        title: Additional Details
+        description: Any additional information about the physiological experiment.
+        range: string
+
   MeasuredCO2Fields:
     mixin: true
     description: Fields applied to all measured CO2 variable types (discrete and continuous)
@@ -675,7 +786,7 @@ slots:
     range: string
     # TODO: Upgrade this to controlled vocab with QUDT
 
-  # DiscreteMeasuredVariable slots
+  # MeasuredVariable slots
   analyzing_instrument:
     title: Analyzing instrument
     description: >-
@@ -769,6 +880,15 @@ enums:
         description: Sediment variable — use with Discrete/ContinuousSedimentVariable or CalculatedVariable
       hplc:
         description: HPLC pigment analysis — use with HPLCVariable (always discrete, always measured)
+      physiological:
+        description: >-
+          Physiological response variable — organism response data from
+          field experiments. Use with
+          Discrete/ContinuousPhysiologicalVariable or CalculatedVariable.
+      socioeconomic:
+        description: >-
+          Socioeconomic variable — social and economic data. Use only
+          with SocioeconomicVariable. Does not include QC fields.
       other:
         description: >-
           Any directly measured or calculated variable that does not fall into a
@@ -813,5 +933,45 @@ enums:
         description: Concentration expressed per unit volume (e.g., μmol/L, mmol/L)
       per_mass:
         description: Concentration expressed per unit mass (e.g., μmol/kg-seawater)
+
+  TaxonomicCodeSystem:
+    description: Taxonomic code system used for species identification.
+    permissible_values:
+      itis:
+        description: Integrated Taxonomic Information System
+      worms:
+        description: World Register of Marine Species
+      col:
+        description: Catalogue of Life
+      pbdb:
+        description: Paleobiology Database
+
+  LifeStage:
+    description: Life stage of the biological subject.
+    permissible_values:
+      egg:
+      embryo:
+      larva:
+      juvenile:
+      adult:
+      other:
+
+  QuantitativeQualitative:
+    description: Whether the socioeconomic data is quantitative or qualitative.
+    permissible_values:
+      quantitative:
+      qualitative:
+
+  SocialStudyType:
+    description: Type of social study conducted.
+    permissible_values:
+      public_perception_survey:
+        description: Public perception survey
+      ecosystem_service_valuation_survey:
+        description: Ecosystem service valuation survey
+      text_analysis:
+        description: Text analysis
+      other:
+        description: Other study type
 
 

--- a/src/oae_data_protocol/schema/variable.yaml
+++ b/src/oae_data_protocol/schema/variable.yaml
@@ -697,40 +697,7 @@ classes:
         title: Life Stage (custom)
         description: Custom life stage description when "other" is selected.
         range: string
-      targeted_acidity_levels:
-        title: Targeted Acidity or Alkalinity Levels
-        description: >-
-          Target pCO2 or alkalinity levels for the manipulation experiment
-          (e.g., "400, 800, 1200 uatm pCO2").
-        range: string
-      manipulation_method:
-        title: Manipulation Method
-        description: >-
-          How ocean chemistry conditions were manipulated (e.g., CO2
-          bubbling, acid addition, alkalinity addition).
-        range: string
-      experiment_location:
-        title: Experiment Location
-        description: >-
-          Where the experiment was carried out (e.g., outdoor mesocosm
-          facility, natural field site).
-        range: string
-      subject_collection_location:
-        title: Subject Collection Location
-        description: Where the biological subjects were collected from.
-        range: string
-      treatment_start_datetime:
-        title: Treatment Start Date/Time
-        description: Start of the experimental treatment period (UTC).
-        range: datetime
-      treatment_end_datetime:
-        title: Treatment End Date/Time
-        description: End of the experimental treatment period (UTC).
-        range: datetime
-      additional_details:
-        title: Additional Details
-        description: Any additional information about the physiological experiment.
-        range: string
+
 
   MeasuredCO2Fields:
     mixin: true


### PR DESCRIPTION
Here's how I've added these new variable types:
- **socioeconomic** is under [`InSituVariable`](https://schema.oaedata.org/pr-preview/pr-30/InSituVariable/), so it has all those standard fields of the InSituVariable variable type (not a user-facing variable name, this is just one we use in the schema to group together all the Discrete and Measured variables). 
  - Importantly, nesting it under `InSituVariable` means that socioeconomic has the following optional fields:
    - [method_reference](https://schema.oaedata.org/pr-preview/pr-30/method_reference/)
    - [measurement_researcher](https://schema.oaedata.org/pr-preview/pr-30/measurement_researcher/)
    - [other_detailed_information](https://schema.oaedata.org/pr-preview/pr-30/other_detailed_information/)
  - Fields that are specific to Socioeconomic can be found [here](https://schema.oaedata.org/pr-preview/pr-30/SocioeconomicVariable/)
- **physiological** is similar to all the other main variables (like pH, sediment, etc.) in that it can be "Calculated", "Discrete", or "Continuous". 
  - For Discrete & Continuous physiological variables, we add these following specific physiological fields [here](https://schema.oaedata.org/pr-preview/pr-30/MeasuredPhysiologicalFields/).

Some questions that came up along the way:
1. **Socioeconomic units**: `units` is currently required for SocioeconomicVariable (also inherited from InSituVariable), is that OK?
3. **Physiological variable discrete/continuous/calculated**: Physiological variables currently can be both discrete and continuous, following the same pattern as pH, TA, DIC, etc. A researcher selects "Physiological" as the variable type, then chooses measured (discrete or continuous) or calculated.  Do all of these options apply?


Let me know if you have any feedback or suggestions to change the above.


corresponding Metadata Builder PR is here: https://github.com/submarine-mrv/oae-metadata-builder/pull/42